### PR TITLE
Support for Card and Keyword iteration on header

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.fits filter=lfs diff=lfs merge=lfs -text

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fitsrs"
-version = "0.2.11"
+version = "0.2.12"
 authors = ["Matthieu Baumann <matthieu.baumann@astro.unistra.fr>"]
 edition = "2018"
 description = "Implementation of the FITS image parser"
@@ -18,7 +18,6 @@ exclude = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nom = "7.1.1"
 byteorder = "1.4.2"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Fits reader written in pure Rust using [nom](https://github.com/Geal/nom)
--------------------------------------------------------------------------
+Fits reader written in pure Rust
+--------------------------------
 
 [![](https://img.shields.io/crates/v/fitsrs.svg)](https://crates.io/crates/fitsrs)
 [![](https://img.shields.io/crates/d/fitsrs.svg)](https://crates.io/crates/fitsrs)
@@ -12,6 +12,24 @@ This fits parser only supports image data (not tables), and does not know anythi
 For WCS parsing, see [wcsrs](https://github.com/cds-astro/wcs-rs).
 This parser is able to parse extension HDUs. Ascii tables and binary tables are still not properly parsed, only the list bytes of their data block can be retrieved but no interpretation/parsing is done on it.
 
+Contributing
+------------
+
+> [!WARNING]
+> Running the test involves test files you can download [here](https://alasky.cds.unistra.fr/Aladin-Lite-test-files/fits-rs-test-files.tar). This tar is 2.2GB.
+
+Once the tar file has been downloaded, put it into the root on your cloned repo and extract it:
+
+```bash
+tar -xvf fits-rs-test-files.tar
+```
+
+Once the files have been extracted you can run the tests locally:
+
+```bash
+cargo test --release
+```
+
 To Do list
 ----------
 
@@ -20,6 +38,7 @@ To Do list
 * [X] Support big fits file parsing that may not fit in memory (iterator usage)
 * [X] Async reading (experimental and not tested)
 * [ ] Keep CARD comment
+* [ ] Support compressed fits files (https://fits.gsfc.nasa.gov/registry/tilecompression.html)
 * [ ] Support data table (each column can have a specific types)
 * [X] Support of multiple HDU, fits extensions (in progress, only the header is parsed)
 * [ ] WCS parsing, see [wcsrs](https://github.com/cds-astro/wcs-rs)

--- a/fitswasm/README.md
+++ b/fitswasm/README.md
@@ -1,4 +1,4 @@
-# FITS reader written in pure Rust using [nom](https://github.com/Geal/nom)
+# FITS reader written in pure Rust
 
 ## Install with npm
 

--- a/samples/misc/AKAI013000932.fits
+++ b/samples/misc/AKAI013000932.fits
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:382a9ab58ffc59d9b01d31d7eb9b1963106097758fdc63341d82e53cecb1ace0
-size 7405052

--- a/samples/misc/ji0590044.fits
+++ b/samples/misc/ji0590044.fits
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7187782cbabb512dadc9cc1c9152a4c05f5a5312a8212564687202fafc1b8e59
-size 1608298

--- a/src/card.rs
+++ b/src/card.rs
@@ -1,12 +1,5 @@
 use std::string::FromUtf8Error;
 
-use nom::{
-    character::complete::{i64, space0},
-    combinator::map,
-    sequence::preceded,
-    IResult,
-};
-
 use crate::error::Error;
 pub type Keyword = [u8; 8];
 
@@ -91,10 +84,6 @@ impl Value {
             _ => Err(Error::ValueBadParsing),
         }
     }
-}
-
-pub(crate) fn parse_integer(buf: &[u8]) -> IResult<&[u8], Value> {
-    preceded(space0, map(i64, |val| Value::Integer(val)))(buf)
 }
 
 #[cfg(test)]

--- a/src/card.rs
+++ b/src/card.rs
@@ -1,3 +1,5 @@
+use std::{str, string::FromUtf8Error};
+
 use nom::{
     character::complete::{i64, space0},
     combinator::map,
@@ -18,6 +20,11 @@ pub struct Card {
 impl Card {
     pub fn new(kw: Keyword, v: Value) -> Self {
         Self { kw, v }
+    }
+    /// Return the ASCII trimmed keyword as an owned String.
+    pub fn keyword(&self) -> Result<String, FromUtf8Error> {
+        let kw = self.kw.trim_ascii().to_vec();
+        String::from_utf8(kw)
     }
 }
 
@@ -88,4 +95,17 @@ impl Value {
 
 pub(crate) fn parse_integer(buf: &[u8]) -> IResult<&[u8], Value> {
     preceded(space0, map(i64, |val| Value::Integer(val)))(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Card, Value};
+
+    #[test]
+    fn trimmed_keyword_string() {
+        let kw = b"GAIN    ".to_owned();
+        let v = Value::Float(30.00);
+        let card = Card { kw, v };
+        assert_eq!("GAIN".to_owned(), card.keyword().unwrap())
+    }
 }

--- a/src/card.rs
+++ b/src/card.rs
@@ -1,4 +1,4 @@
-use std::{str, string::FromUtf8Error};
+use std::string::FromUtf8Error;
 
 use nom::{
     character::complete::{i64, space0},

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,10 +25,6 @@ quick_error! {
         NotSupportedXtensionType(extension: String) {
             display("`{}` extension is not supported. Only BINTABLE, TABLE and IMAGE are.", extension)
         }
-        Nom {
-            from(nom::Err<nom::error::Error<&[u8]>>)
-            display("Nom could not parse header values")
-        }
         Utf8 {
             from(std::str::Utf8Error)
             display("Fail to parse a keyword as a utf8 string")

--- a/src/hdu/header/mod.rs
+++ b/src/hdu/header/mod.rs
@@ -7,7 +7,10 @@ use serde::Serialize;
 
 pub mod extension;
 
-use std::collections::HashMap;
+use std::collections::hash_map::Keys;
+use std::collections::{
+    hash_map::Iter, HashMap
+};
 use std::io::Read;
 
 use crate::card::*;
@@ -256,6 +259,18 @@ where
             })
         })
     }
+
+    pub fn keywords(&self) -> Keys<Keyword,Value> {
+        self.cards.keys()
+    }
+
+    pub fn cards(&self) -> impl Iterator<Item = Card> + use<'_, X> {
+        self.cards.iter()
+            .map(|(kw,v)| {
+                Card { kw: kw.to_owned(), v: v.to_owned() }
+            })
+    }
+
 }
 
 fn parse_pcount_card(card: &[u8; 80]) -> Result<usize, Error> {

--- a/src/hdu/header/mod.rs
+++ b/src/hdu/header/mod.rs
@@ -8,9 +8,7 @@ use serde::Serialize;
 pub mod extension;
 
 use std::collections::hash_map::Keys;
-use std::collections::{
-    hash_map::Iter, HashMap
-};
+use std::collections::HashMap;
 use std::io::Read;
 
 use crate::card::*;
@@ -260,17 +258,16 @@ where
         })
     }
 
-    pub fn keywords(&self) -> Keys<Keyword,Value> {
+    pub fn keywords(&self) -> Keys<Keyword, Value> {
         self.cards.keys()
     }
 
     pub fn cards(&self) -> impl Iterator<Item = Card> + use<'_, X> {
-        self.cards.iter()
-            .map(|(kw,v)| {
-                Card { kw: kw.to_owned(), v: v.to_owned() }
-            })
+        self.cards.iter().map(|(kw, v)| Card {
+            kw: kw.to_owned(),
+            v: v.to_owned(),
+        })
     }
-
 }
 
 fn parse_pcount_card(card: &[u8; 80]) -> Result<usize, Error> {
@@ -307,6 +304,66 @@ mod tests {
                 kw: b"CDS_1   ".to_owned(),
                 v: Value::Logical(true)
             }))
+        );
+    }
+
+    use crate::fits::Fits;
+    use std::fs::File;
+    use std::io::Cursor;
+    use std::io::Read;
+    #[test]
+    fn test_keywords_iter() {
+        let f = File::open("samples/misc/SN2923fxjA.fits").unwrap();
+        let bytes: Result<Vec<_>, _> = f.bytes().collect();
+        let buf = bytes.unwrap();
+
+        let mut reader = Cursor::new(&buf[..]);
+        let Fits { hdu } = Fits::from_reader(&mut reader).unwrap();
+
+        let header = hdu.get_header();
+        let mut keywords = header
+            .cards()
+            .map(|c| c.keyword())
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        keywords.sort_unstable();
+
+        assert_eq!(
+            keywords,
+            vec![
+                "BAYERIND", "BITCAMPX", "CALPHOT", "CCD-TEMP", "CD1_1", "CD1_2", "CD2_1", "CD2_2",
+                "CDELT1", "CDELT2", "CDELTM1", "CDELTM2", "COMMENT", "COMPRESS", "CRPIX1",
+                "CRPIX2", "CRVAL1", "CRVAL2", "CTYPE1", "CTYPE2", "CUNIT1", "CUNIT2", "CVF",
+                "DATAMAX", "DATAMIN", "DATE", "DATE-OBS", "DEC", "DEWPOINT", "DIAMETER", "ERRFLUX",
+                "EXPOSURE", "FILTERS", "FOCAL", "FOCUSPOS", "FOCUSTMP", "GAIN_ELE", "HISTORY",
+                "HUMIDITY", "IMGTYPE", "INSTRUME", "MAGREF", "MIRORX", "NAXIS", "NAXIS1", "NAXIS2",
+                "OBJCTDEC", "OBJCTRA", "OBSERVER", "OFFSET_E", "ORIGIN", "P3DSPHER", "PCXASTRO",
+                "PCYASTRO", "PDEC_REF", "PDIMPOL", "PIERSIDE", "PPLATESD", "PPXC", "PPYC",
+                "PRADIUSX", "PRADIUSY", "PRA_REF", "PRESSURE", "PSOLDC1", "PSOLDC10", "PSOLDC11",
+                "PSOLDC12", "PSOLDC13", "PSOLDC14", "PSOLDC15", "PSOLDC16", "PSOLDC17", "PSOLDC18",
+                "PSOLDC19", "PSOLDC2", "PSOLDC20", "PSOLDC21", "PSOLDC22", "PSOLDC23", "PSOLDC24",
+                "PSOLDC25", "PSOLDC26", "PSOLDC27", "PSOLDC28", "PSOLDC29", "PSOLDC3", "PSOLDC30",
+                "PSOLDC31", "PSOLDC32", "PSOLDC33", "PSOLDC34", "PSOLDC35", "PSOLDC36", "PSOLDC4",
+                "PSOLDC5", "PSOLDC6", "PSOLDC7", "PSOLDC8", "PSOLDC9", "PSOLRA1", "PSOLRA10",
+                "PSOLRA11", "PSOLRA12", "PSOLRA13", "PSOLRA14", "PSOLRA15", "PSOLRA16", "PSOLRA17",
+                "PSOLRA18", "PSOLRA19", "PSOLRA2", "PSOLRA20", "PSOLRA21", "PSOLRA22", "PSOLRA23",
+                "PSOLRA24", "PSOLRA25", "PSOLRA26", "PSOLRA27", "PSOLRA28", "PSOLRA29", "PSOLRA3",
+                "PSOLRA30", "PSOLRA31", "PSOLRA32", "PSOLRA33", "PSOLRA34", "PSOLRA35", "PSOLRA36",
+                "PSOLRA4", "PSOLRA5", "PSOLRA6", "PSOLRA7", "PSOLRA8", "PSOLRA9", "PSOLX1",
+                "PSOLX10", "PSOLX11", "PSOLX12", "PSOLX13", "PSOLX14", "PSOLX15", "PSOLX16",
+                "PSOLX17", "PSOLX18", "PSOLX19", "PSOLX2", "PSOLX20", "PSOLX21", "PSOLX22",
+                "PSOLX23", "PSOLX24", "PSOLX25", "PSOLX26", "PSOLX27", "PSOLX28", "PSOLX29",
+                "PSOLX3", "PSOLX30", "PSOLX31", "PSOLX32", "PSOLX33", "PSOLX34", "PSOLX35",
+                "PSOLX36", "PSOLX4", "PSOLX5", "PSOLX6", "PSOLX7", "PSOLX8", "PSOLX9", "PSOLY1",
+                "PSOLY10", "PSOLY11", "PSOLY12", "PSOLY13", "PSOLY14", "PSOLY15", "PSOLY16",
+                "PSOLY17", "PSOLY18", "PSOLY19", "PSOLY2", "PSOLY20", "PSOLY21", "PSOLY22",
+                "PSOLY23", "PSOLY24", "PSOLY25", "PSOLY26", "PSOLY27", "PSOLY28", "PSOLY29",
+                "PSOLY3", "PSOLY30", "PSOLY31", "PSOLY32", "PSOLY33", "PSOLY34", "PSOLY35",
+                "PSOLY36", "PSOLY4", "PSOLY5", "PSOLY6", "PSOLY7", "PSOLY8", "PSOLY9", "PSSX",
+                "PSSY", "RA", "READOUTT", "REFFLUX", "SITELAT", "SITELONG", "STACKNB", "STARCNT",
+                "SWCREATE", "TELESCOP", "TEMPEXT", "UT", "WINDIR", "WINSPEED", "X1", "X2",
+                "XPIXELSZ", "XPIXSZ", "Y1", "Y2", "YPIXELSZ", "YPIXSZ"
+            ]
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,6 @@
 
 extern crate async_trait;
 extern crate byteorder;
-extern crate nom;
 #[macro_use]
 extern crate quick_error;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,8 +197,6 @@ mod tests {
     #[test_case("samples/misc/P122_49.fits")]
     #[test_case("samples/misc/skv1678175163788.fits")]
     #[test_case("samples/misc/SN2923fxjA.fits")]
-    //#[test_case("samples/misc/ji0590044.fits")] gzip compressed data
-    //#[test_case("samples/misc/AKAI013000932.fits")] gzip compressed data
     fn test_fits_opening(filename: &str) {
         use std::fs::File;
 


### PR DESCRIPTION
This PR relates to the question raised in Issue #9 and provides support for the following:

* Iterate over all Cards and Keywords defined for a Header.
* Retrieve the Keyword of a Card as a trimmed and owned String.

Note 1: I did not create test cases for the Card and Keyword iterators due to the issue related to `git-lfs` reported in issue #10. On the other hand, this change is trivial and was tested locally from another project.

Note 2: Retrieving the Keyword as a trimmed and owned String can be considered syntactic sugar, but it scratches the itch of having to work with byte arrays for Strings...