### PR TITLE
changed from returning owned to borrowed keyword string in card

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 Cargo.lock
 target/
-samples/
 fitswasm/node_modules
 fitswasm/test
 fitswasm/Cargo.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 Cargo.lock
 target/
+samples/
 fitswasm/node_modules
 fitswasm/test
 fitswasm/Cargo.lock
 fitswasm/target
 fitswasm/pkg
+fits-rs-test-files.tar*
 .DS_Store

--- a/src/card.rs
+++ b/src/card.rs
@@ -1,4 +1,4 @@
-use std::string::FromUtf8Error;
+use std::str::Utf8Error;
 
 use crate::error::Error;
 pub type Keyword = [u8; 8];
@@ -15,9 +15,8 @@ impl Card {
         Self { kw, v }
     }
     /// Return the ASCII trimmed keyword as an owned String.
-    pub fn keyword(&self) -> Result<String, FromUtf8Error> {
-        let kw = self.kw.trim_ascii().to_vec();
-        String::from_utf8(kw)
+    pub fn keyword(&self) -> Result<&str, Utf8Error> {
+        std::str::from_utf8(&self.kw)
     }
 }
 

--- a/src/card.rs
+++ b/src/card.rs
@@ -16,7 +16,7 @@ impl Card {
     }
     /// Return the ASCII trimmed keyword as an owned String.
     pub fn keyword(&self) -> Result<&str, Utf8Error> {
-        std::str::from_utf8(&self.kw)
+        std::str::from_utf8(self.kw.trim_ascii())
     }
 }
 

--- a/src/hdu/header/mod.rs
+++ b/src/hdu/header/mod.rs
@@ -323,9 +323,8 @@ mod tests {
         let header = hdu.get_header();
         let mut keywords = header
             .cards()
-            .map(|c| c.keyword())
-            .collect::<Result<Vec<_>, _>>()
-            .unwrap();
+            .map(|c| c.keyword().unwrap().to_owned())
+            .collect::<Vec<_>>();
         keywords.sort_unstable();
 
         assert_eq!(


### PR DESCRIPTION
No need for returning an owned string in the keyword method on card. Should be marginally more efficient.