### PR TITLE
Relax bound on DataBufRead for Cursor

### DIFF
--- a/src/hdu/data/asciitable.rs
+++ b/src/hdu/data/asciitable.rs
@@ -13,7 +13,7 @@ use crate::hdu::header::extension::Xtension;
 
 impl<'a, R> DataBufRead<'a, AsciiTable> for Cursor<R>
 where
-    R: AsRef<[u8]> + Debug + Read + 'a,
+    R: AsRef<[u8]> + Debug + 'a,
 {
     type Data = Data<'a>;
 

--- a/src/hdu/data/bintable.rs
+++ b/src/hdu/data/bintable.rs
@@ -15,7 +15,7 @@ use crate::hdu::header::extension::Xtension;
 
 impl<'a, R> DataBufRead<'a, BinTable> for Cursor<R>
 where
-    R: AsRef<[u8]> + Debug + Read + 'a,
+    R: AsRef<[u8]> + Debug + 'a,
 {
     type Data = Data<'a>;
 

--- a/src/hdu/data/image.rs
+++ b/src/hdu/data/image.rs
@@ -16,7 +16,7 @@ use crate::hdu::DataBufRead;
 
 impl<'a, R> DataBufRead<'a, Image> for Cursor<R>
 where
-    R: AsRef<[u8]> + Debug + Read + 'a,
+    R: AsRef<[u8]> + Debug + 'a,
 {
     type Data = Data<'a>;
 


### PR DESCRIPTION
This bound is overly restrictive - the point of Cursor<R> is to provide a Read implementation for any byte buffer.

Thus, it doesn't make sense to require that buffer itself also implements Read, as it prevents usage of Cursor with types like Vec<u8>, Rc<[u8]>, memmap2::Map and others.