### PR TITLE
Data offset in hdu

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,17 +104,17 @@ mod tests {
         assert!(hdu_list.next().is_none());
     }
 
-    #[test_case("samples/fits.gsfc.nasa.gov/Astro_UIT.fits", 2, 0, 0)]
-    #[test_case("samples/fits.gsfc.nasa.gov/EUVE.fits", 6, 0, 4)]
-    #[test_case("samples/fits.gsfc.nasa.gov/HST_FGS.fits", 2, 1, 0)]
-    #[test_case("samples/fits.gsfc.nasa.gov/IUE_LWP.fits", 2, 0, 1)]
-    #[test_case("samples/misc/ngc5457K.fits", 2, 0, 0)]
-    #[test_case("samples/fits.gsfc.nasa.gov/HST_FOC.fits", 2, 1, 0)]
-    #[test_case("samples/fits.gsfc.nasa.gov/HST_FOS.fits", 2, 1, 0)]
-    #[test_case("samples/fits.gsfc.nasa.gov/HST_HRS.fits", 2, 1, 0)]
-    #[test_case("samples/fits.gsfc.nasa.gov/HST_NICMOS.fits", 7, 0, 0)]
-    #[test_case("samples/fits.gsfc.nasa.gov/HST_WFPC_II.fits", 2, 1, 0)]
-    #[test_case("samples/fits.gsfc.nasa.gov/HST_WFPC_II_bis.fits", 2, 0, 0)]
+    #[test_case("samples/fits.gsfc.nasa.gov/Astro_UIT.fits",1,0,0)]
+    #[test_case("samples/fits.gsfc.nasa.gov/EUVE.fits",5,0,4)]
+    #[test_case("samples/fits.gsfc.nasa.gov/HST_FGS.fits",1,1,0)]
+    #[test_case("samples/fits.gsfc.nasa.gov/IUE_LWP.fits",1,0,1)]
+    #[test_case("samples/misc/ngc5457K.fits",1,0,0)]
+    #[test_case("samples/fits.gsfc.nasa.gov/HST_FOC.fits",1,1,0)]
+    #[test_case("samples/fits.gsfc.nasa.gov/HST_FOS.fits",1,1,0)]
+    #[test_case("samples/fits.gsfc.nasa.gov/HST_HRS.fits",1,1,0)]
+    #[test_case("samples/fits.gsfc.nasa.gov/HST_NICMOS.fits",6,0,0)]
+    #[test_case("samples/fits.gsfc.nasa.gov/HST_WFPC_II.fits",1,1,0)]
+    #[test_case("samples/fits.gsfc.nasa.gov/HST_WFPC_II_bis.fits",1,0,0)]
     fn test_fits_count_hdu(
         filename: &str,
         num_image_ext: usize,
@@ -123,7 +123,7 @@ mod tests {
     ) {
         let mut hdu_list = FITSFile::open(filename).unwrap();
 
-        let mut n_image_ext = 1; // because the primary hdu is an image
+        let mut n_image_ext = 0; // the primary HDU is counted below
         let mut n_bintable_ext = 0;
         let mut n_asciitable_ext = 0;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@ mod tests {
         num_image_ext: usize,
         num_asciitable_ext: usize,
         num_bintable_ext: usize,
-        byte_offsets: &[usize],
+        byte_offsets: &[u64],
         byte_lengths: &[u64],
     ) {
         let mut hdu_list = FITSFile::open(filename).unwrap();
@@ -133,19 +133,18 @@ mod tests {
 
         while let Some(Ok(hdu)) = hdu_list.next() {
             match &hdu {
-                HDU::Primary(h) | HDU::XImage(h) => {
+                HDU::Primary(_) | HDU::XImage(_) => {
                     n_image_ext += 1;
-                    seen_byte_lengths.push(h.get_header().get_xtension().get_num_bytes_data_block());
                 }
-                HDU::XBinaryTable(h) => {
+                HDU::XBinaryTable(_) => {
                     n_bintable_ext += 1;
-                    seen_byte_lengths.push(h.get_header().get_xtension().get_num_bytes_data_block());}
-                HDU::XASCIITable(h) => {
-                    n_asciitable_ext += 1;
-                    seen_byte_lengths.push(h.get_header().get_xtension().get_num_bytes_data_block());
                 }
-            }
-            seen_byte_offsets.push(hdu_list.get_position_data_unit());
+                HDU::XASCIITable(_) => {
+                    n_asciitable_ext += 1;
+                }
+            };
+            seen_byte_lengths.push(hdu.get_data_unit_byte_size());
+            seen_byte_offsets.push(hdu.get_data_unit_byte_offset())
         }
 
         assert_eq!(n_image_ext, num_image_ext);


### PR DESCRIPTION
Per #27, add new methods to `fitsrs::hdu::HDU` which give you the offset and length, in bytes, of the data unit associated with the HDU. The new methods are `get_data_unit_byte_size()` and `get_data_unit_byte_offset()`

I don't love the way I did it, having it be a member that gets set after initialization. I looked a bit at restructuring the logic of HDU creation to gain access to the information early enough to add it at construction time, but I was afraid of breaking things.

I also haven't done anything with the async HDU, mostly because I didn't notice them at first since i don't use async with fitrs. I'm not sure it's as important, since the async API seems more oriented around fetching the entire data block?