### PR TITLE
Simplify num pixels assertions in tests

### DIFF
--- a/benches/decompress.rs
+++ b/benches/decompress.rs
@@ -66,18 +66,18 @@ fn read_image() {
                     .get_header()
                     .get_parsed::<i64>("NAXIS1")
                     .unwrap()
-                    .unwrap() as u32;
+                    .unwrap() as usize;
                 let height = hdu
                     .get_header()
                     .get_parsed::<i64>("NAXIS2")
                     .unwrap()
-                    .unwrap() as u32;
+                    .unwrap() as usize;
                 let pixels = match hdu_list.get_data(&hdu).pixels() {
-                    Pixels::I16(it) => it.collect::<Vec<_>>(),
+                    Pixels::I16(it) => it.count(),
                     _ => unreachable!(),
                 };
 
-                assert!(width * height == pixels.len() as u32);
+                assert!(width * height == pixels);
             }
             _ => (),
         }

--- a/src/hdu/header/extension/image.rs
+++ b/src/hdu/header/extension/image.rs
@@ -36,19 +36,20 @@ impl Image {
     pub fn get_bitpix(&self) -> Bitpix {
         self.bitpix
     }
+
+    /// Get total number of pixels in the image
+    pub fn get_num_pixels(&self) -> u64 {
+        if self.naxisn.is_empty() {
+            return 0;
+        }
+        self.naxisn.iter().product()
+    }
 }
 
 #[async_trait(?Send)]
 impl Xtension for Image {
     fn get_num_bytes_data_block(&self) -> u64 {
-        let num_pixels = if self.naxisn.is_empty() {
-            0
-        } else {
-            self.naxisn.iter().product()
-        };
-
-        let num_bits = ((self.bitpix as i32).unsigned_abs() as u64) * num_pixels;
-        num_bits >> 3
+        self.bitpix.byte_size() as u64 * self.get_num_pixels()
     }
 
     fn parse(values: &HashMap<String, Value>) -> Result<Self, Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,8 +167,7 @@ mod tests {
         assert!(matches!(hdu, HDU::Primary(_)));
         if let HDU::Primary(hdu) = hdu {
             let header = hdu.get_header();
-            let num_pixels = header.get_xtension().get_naxisn(1).unwrap()
-                * header.get_xtension().get_naxisn(2).unwrap();
+            let num_pixels = header.get_xtension().get_num_pixels();
             let image = hdu_list.get_data(&hdu);
             match image.pixels() {
                 Pixels::F32(it) => {
@@ -194,8 +193,7 @@ mod tests {
         assert!(matches!(hdu, HDU::Primary(_)));
         if let HDU::Primary(hdu) = hdu {
             let header = hdu.get_header();
-            let num_pixels = header.get_xtension().get_naxisn(1).unwrap()
-                * header.get_xtension().get_naxisn(2).unwrap();
+            let num_pixels = header.get_xtension().get_num_pixels();
             let image = hdu_list.get_data(&hdu);
             match image.pixels() {
                 Pixels::I16(data) => {
@@ -259,11 +257,7 @@ mod tests {
         let mut hdu_list = Fits::from_reader(reader);
 
         while let Some(Ok(HDU::XImage(hdu))) = hdu_list.next() {
-            let xtension = hdu.get_header().get_xtension();
-            let naxis1 = *xtension.get_naxisn(1).unwrap();
-            let naxis2 = *xtension.get_naxisn(2).unwrap();
-
-            let num_pixels = (naxis1 * naxis2) as usize;
+            let num_pixels = hdu.get_header().get_xtension().get_num_pixels();
 
             // Try to access the WCS on a specific HDU image
             if let Ok(wcs) = hdu.wcs() {
@@ -274,7 +268,7 @@ mod tests {
 
             let image = hdu_list.get_data(&hdu);
             assert_eq!(
-                num_pixels,
+                num_pixels as usize,
                 match image.pixels() {
                     Pixels::I16(it) => it.count(),
                     Pixels::U8(it) => it.count(),
@@ -299,13 +293,11 @@ mod tests {
         let mut hdu_list = Fits::from_reader(reader);
 
         if let Some(Ok(HDU::Primary(hdu))) = hdu_list.next() {
-            let xtension = hdu.get_header().get_xtension();
-            let naxis1 = *xtension.get_naxisn(1).unwrap();
-            let naxis2 = *xtension.get_naxisn(2).unwrap();
+            let num_pixels = hdu.get_header().get_xtension().get_num_pixels();
             let image = hdu_list.get_data(&hdu);
             match image.pixels() {
                 Pixels::F32(data) => {
-                    assert_eq!(data.count(), (naxis1 * naxis2) as usize);
+                    assert_eq!(data.count(), num_pixels as usize);
                 }
                 _ => unreachable!(),
             }
@@ -401,27 +393,20 @@ mod tests {
         while let Some(Ok(hdu)) = hdu_list.next() {
             match hdu {
                 HDU::XImage(hdu) | HDU::Primary(hdu) => {
-                    let xtension = hdu.get_header().get_xtension();
+                    let num_pixels = hdu.get_header().get_xtension().get_num_pixels();
 
-                    let naxis1 = xtension.get_naxisn(1);
-                    let naxis2 = xtension.get_naxisn(2);
-
-                    if let (Some(naxis1), Some(naxis2)) = (naxis1, naxis2) {
-                        let num_pixels = (naxis2 * naxis1) as usize;
-
-                        let image = hdu_list.get_data(&hdu);
-                        assert_eq!(
-                            num_pixels,
-                            match image.pixels() {
-                                Pixels::U8(it) => it.count(),
-                                Pixels::I16(it) => it.count(),
-                                Pixels::I32(it) => it.count(),
-                                Pixels::I64(it) => it.count(),
-                                Pixels::F32(it) => it.count(),
-                                Pixels::F64(it) => it.count(),
-                            }
-                        );
-                    };
+                    let image = hdu_list.get_data(&hdu);
+                    assert_eq!(
+                        num_pixels as usize,
+                        match image.pixels() {
+                            Pixels::U8(it) => it.count(),
+                            Pixels::I16(it) => it.count(),
+                            Pixels::I32(it) => it.count(),
+                            Pixels::I64(it) => it.count(),
+                            Pixels::F32(it) => it.count(),
+                            Pixels::F64(it) => it.count(),
+                        }
+                    );
                 }
                 HDU::XBinaryTable(hdu) => {
                     let _num_bytes = hdu.get_header().get_xtension().get_num_bytes_data_block();
@@ -453,12 +438,7 @@ mod tests {
         while let Some(Ok(hdu)) = hdu_list.next() {
             match hdu {
                 HDU::XImage(hdu) => {
-                    let xtension = hdu.get_header().get_xtension();
-
-                    let naxis1 = *xtension.get_naxisn(1).unwrap();
-                    let naxis2 = *xtension.get_naxisn(2).unwrap();
-
-                    let num_pixels = naxis2 * naxis1;
+                    let num_pixels = hdu.get_header().get_xtension().get_num_pixels();
 
                     let image = hdu_list.get_data(&hdu);
                     assert_eq!(
@@ -533,24 +513,19 @@ mod tests {
         while let Some(Ok(hdu)) = hdu_list.next().await {
             match hdu {
                 AsyncHDU::XImage(hdu) | AsyncHDU::Primary(hdu) => {
-                    let xtension = hdu.get_header().get_xtension();
-                    let naxis1 = xtension.get_naxisn(1);
-                    let naxis2 = xtension.get_naxisn(2);
-                    if let (Some(naxis1), Some(naxis2)) = (naxis1, naxis2) {
-                        let num_pixels = (*naxis2 * *naxis1) as usize;
+                    let num_pixels = hdu.get_header().get_xtension().get_num_pixels();
 
-                        assert_eq!(
-                            num_pixels,
-                            match hdu_list.get_data(&hdu) {
-                                DataStream::U8(st) => st.count().await,
-                                DataStream::I16(st) => st.count().await,
-                                DataStream::I32(st) => st.count().await,
-                                DataStream::I64(st) => st.count().await,
-                                DataStream::F32(st) => st.count().await,
-                                DataStream::F64(st) => st.count().await,
-                            }
-                        );
-                    }
+                    assert_eq!(
+                        num_pixels as usize,
+                        match hdu_list.get_data(&hdu) {
+                            DataStream::U8(st) => st.count().await,
+                            DataStream::I16(st) => st.count().await,
+                            DataStream::I32(st) => st.count().await,
+                            DataStream::I64(st) => st.count().await,
+                            DataStream::F32(st) => st.count().await,
+                            DataStream::F64(st) => st.count().await,
+                        }
+                    );
                 }
                 AsyncHDU::XBinaryTable(hdu) => {
                     let num_bytes = hdu.get_header().get_xtension().get_num_bytes_data_block();
@@ -581,16 +556,11 @@ mod tests {
                 // skip the primary HDU
                 HDU::Primary(_) => (),
                 HDU::XImage(hdu) => {
-                    let xtension = hdu.get_header().get_xtension();
-
-                    let naxis1 = *xtension.get_naxisn(1).unwrap();
-                    let naxis2 = *xtension.get_naxisn(2).unwrap();
-
-                    let num_pixels = (naxis2 * naxis1) as usize;
+                    let num_pixels = hdu.get_header().get_xtension().get_num_pixels();
 
                     let data = hdu_list.get_data(&hdu);
                     assert_eq!(
-                        num_pixels,
+                        num_pixels as usize,
                         match data.pixels() {
                             Pixels::U8(it) => it.count(),
                             Pixels::I16(it) => it.count(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,8 +21,7 @@
 //!
 //!     let image = hdu_list.get_data(&hdu);
 //!     if let Pixels::F32(it) = image.pixels() {
-//!         let data = it.collect::<Vec<_>>();
-//!         assert_eq!(data.len(), naxis1 * naxis2);
+//!         assert_eq!(it.count(), naxis1 * naxis2);
 //!     } else {
 //!         panic!("expected data block containing f32");
 //!     }
@@ -173,7 +172,7 @@ mod tests {
             let image = hdu_list.get_data(&hdu);
             match image.pixels() {
                 Pixels::F32(it) => {
-                    assert!(it.collect::<Vec<_>>().len() as u64 == num_pixels);
+                    assert!(it.count() as u64 == num_pixels);
                 }
                 _ => unreachable!(),
             }
@@ -200,7 +199,7 @@ mod tests {
             let image = hdu_list.get_data(&hdu);
             match image.pixels() {
                 Pixels::I16(data) => {
-                    assert!(data.collect::<Vec<_>>().len() as u64 == num_pixels)
+                    assert!(data.count() as u64 == num_pixels)
                 }
                 _ => unreachable!(),
             }
@@ -274,32 +273,17 @@ mod tests {
             }
 
             let image = hdu_list.get_data(&hdu);
-            match image.pixels() {
-                Pixels::I16(it) => {
-                    let data = it.collect::<Vec<_>>();
-                    assert_eq!(data.len(), num_pixels);
+            assert_eq!(
+                num_pixels,
+                match image.pixels() {
+                    Pixels::I16(it) => it.count(),
+                    Pixels::U8(it) => it.count(),
+                    Pixels::I32(it) => it.count(),
+                    Pixels::I64(it) => it.count(),
+                    Pixels::F32(it) => it.count(),
+                    Pixels::F64(it) => it.count(),
                 }
-                Pixels::U8(it) => {
-                    let data = it.collect::<Vec<_>>();
-                    assert_eq!(data.len(), num_pixels);
-                }
-                Pixels::I32(it) => {
-                    let data = it.collect::<Vec<_>>();
-                    assert_eq!(data.len(), num_pixels);
-                }
-                Pixels::I64(it) => {
-                    let data = it.collect::<Vec<_>>();
-                    assert_eq!(data.len(), num_pixels);
-                }
-                Pixels::F32(it) => {
-                    let data = it.collect::<Vec<_>>();
-                    assert_eq!(data.len(), num_pixels);
-                }
-                Pixels::F64(it) => {
-                    let data = it.collect::<Vec<_>>();
-                    assert_eq!(data.len(), num_pixels);
-                }
-            }
+            );
         }
     }
 
@@ -321,7 +305,7 @@ mod tests {
             let image = hdu_list.get_data(&hdu);
             match image.pixels() {
                 Pixels::F32(data) => {
-                    assert_eq!(data.collect::<Vec<_>>().len(), (naxis1 * naxis2) as usize);
+                    assert_eq!(data.count(), (naxis1 * naxis2) as usize);
                 }
                 _ => unreachable!(),
             }
@@ -336,15 +320,15 @@ mod tests {
 
         let reader = BufReader::new(f);
         let mut hdu_list = Fits::from_reader(reader);
-        let mut data = vec![];
+        let mut data_len = 0;
         while let Some(Ok(hdu)) = hdu_list.next() {
             if let HDU::XBinaryTable(hdu) = hdu {
                 let _ = hdu.get_header().get_xtension();
-                data = hdu_list.get_data(&hdu).collect::<Vec<_>>();
+                data_len = hdu_list.get_data(&hdu).count();
             }
         }
 
-        assert_eq!(177 * 23, data.len());
+        assert_eq!(177 * 23, data_len);
     }
 
     #[test]
@@ -426,26 +410,17 @@ mod tests {
                         let num_pixels = (naxis2 * naxis1) as usize;
 
                         let image = hdu_list.get_data(&hdu);
-                        match image.pixels() {
-                            Pixels::U8(it) => {
-                                assert_eq!(num_pixels, it.collect::<Vec<_>>().len())
+                        assert_eq!(
+                            num_pixels,
+                            match image.pixels() {
+                                Pixels::U8(it) => it.count(),
+                                Pixels::I16(it) => it.count(),
+                                Pixels::I32(it) => it.count(),
+                                Pixels::I64(it) => it.count(),
+                                Pixels::F32(it) => it.count(),
+                                Pixels::F64(it) => it.count(),
                             }
-                            Pixels::I16(it) => {
-                                assert_eq!(num_pixels, it.collect::<Vec<_>>().len())
-                            }
-                            Pixels::I32(it) => {
-                                assert_eq!(num_pixels, it.collect::<Vec<_>>().len())
-                            }
-                            Pixels::I64(it) => {
-                                assert_eq!(num_pixels, it.collect::<Vec<_>>().len())
-                            }
-                            Pixels::F32(it) => {
-                                assert_eq!(num_pixels, it.collect::<Vec<_>>().len())
-                            }
-                            Pixels::F64(it) => {
-                                assert_eq!(num_pixels, it.collect::<Vec<_>>().len())
-                            }
-                        }
+                        );
                     };
                 }
                 HDU::XBinaryTable(hdu) => {
@@ -460,7 +435,7 @@ mod tests {
                     let num_bytes = hdu.get_header().get_xtension().get_num_bytes_data_block();
                     let bytes = hdu_list.get_data(&hdu);
 
-                    assert_eq!(num_bytes as usize, bytes.bytes().collect::<Vec<_>>().len());
+                    assert_eq!(num_bytes as usize, bytes.bytes().count());
                 }
             }
         }
@@ -486,32 +461,17 @@ mod tests {
                     let num_pixels = naxis2 * naxis1;
 
                     let image = hdu_list.get_data(&hdu);
-                    match image.pixels() {
-                        Pixels::U8(it) => {
-                            let data = it.collect::<Vec<_>>();
-                            assert_eq!(num_pixels as usize, data.len())
+                    assert_eq!(
+                        num_pixels as usize,
+                        match image.pixels() {
+                            Pixels::U8(it) => it.count(),
+                            Pixels::I16(it) => it.count(),
+                            Pixels::I32(it) => it.count(),
+                            Pixels::I64(it) => it.count(),
+                            Pixels::F32(it) => it.count(),
+                            Pixels::F64(it) => it.count(),
                         }
-                        Pixels::I16(it) => {
-                            let data = it.collect::<Vec<_>>();
-                            assert_eq!(num_pixels as usize, data.len())
-                        }
-                        Pixels::I32(it) => {
-                            let data = it.collect::<Vec<_>>();
-                            assert_eq!(num_pixels as usize, data.len())
-                        }
-                        Pixels::I64(it) => {
-                            let data = it.collect::<Vec<_>>();
-                            assert_eq!(num_pixels as usize, data.len())
-                        }
-                        Pixels::F32(it) => {
-                            let data = it.collect::<Vec<_>>();
-                            assert_eq!(num_pixels as usize, data.len())
-                        }
-                        Pixels::F64(it) => {
-                            let data = it.collect::<Vec<_>>();
-                            assert_eq!(num_pixels as usize, data.len())
-                        }
-                    }
+                    );
                 }
                 HDU::XBinaryTable(_) => {
                     /*let num_bytes = hdu.get_header().get_xtension().get_num_bytes_data_block();
@@ -523,9 +483,7 @@ mod tests {
                 HDU::XASCIITable(hdu) => {
                     let num_bytes = hdu.get_header().get_xtension().get_num_bytes_data_block();
 
-                    let it_bytes = hdu_list.get_data(&hdu);
-                    let data = it_bytes.bytes().collect::<Vec<_>>();
-                    assert_eq!(num_bytes as usize, data.len());
+                    assert_eq!(num_bytes as usize, hdu_list.get_data(&hdu).bytes().count());
                 }
                 _ => (),
             }
@@ -581,47 +539,28 @@ mod tests {
                     if let (Some(naxis1), Some(naxis2)) = (naxis1, naxis2) {
                         let num_pixels = (*naxis2 * *naxis1) as usize;
 
-                        match hdu_list.get_data(&hdu) {
-                            DataStream::U8(st) => {
-                                let data = st.collect::<Vec<_>>().await;
-                                assert_eq!(num_pixels, data.len())
+                        assert_eq!(
+                            num_pixels,
+                            match hdu_list.get_data(&hdu) {
+                                DataStream::U8(st) => st.count().await,
+                                DataStream::I16(st) => st.count().await,
+                                DataStream::I32(st) => st.count().await,
+                                DataStream::I64(st) => st.count().await,
+                                DataStream::F32(st) => st.count().await,
+                                DataStream::F64(st) => st.count().await,
                             }
-                            DataStream::I16(stream) => {
-                                let data = stream.collect::<Vec<_>>().await;
-                                assert_eq!(num_pixels, data.len())
-                            }
-                            DataStream::I32(stream) => {
-                                let data = stream.collect::<Vec<_>>().await;
-                                assert_eq!(num_pixels, data.len());
-                            }
-                            DataStream::I64(stream) => {
-                                let data = stream.collect::<Vec<_>>().await;
-                                assert_eq!(num_pixels, data.len())
-                            }
-                            DataStream::F32(stream) => {
-                                let data = stream.collect::<Vec<_>>().await;
-                                assert_eq!(num_pixels, data.len())
-                            }
-                            DataStream::F64(stream) => {
-                                let data = stream.collect::<Vec<_>>().await;
-                                assert_eq!(num_pixels, data.len())
-                            }
-                        }
+                        );
                     }
                 }
                 AsyncHDU::XBinaryTable(hdu) => {
                     let num_bytes = hdu.get_header().get_xtension().get_num_bytes_data_block();
 
-                    let it_bytes = hdu_list.get_data(&hdu);
-                    let data = it_bytes.collect::<Vec<_>>().await;
-                    assert_eq!(num_bytes as usize, data.len());
+                    assert_eq!(num_bytes as usize, hdu_list.get_data(&hdu).count().await);
                 }
                 AsyncHDU::XASCIITable(hdu) => {
                     let num_bytes = hdu.get_header().get_xtension().get_num_bytes_data_block();
 
-                    let it_bytes = hdu_list.get_data(&hdu);
-                    let data = it_bytes.collect::<Vec<_>>().await;
-                    assert_eq!(num_bytes as usize, data.len());
+                    assert_eq!(num_bytes as usize, hdu_list.get_data(&hdu).count().await);
                 }
             }
         }
@@ -650,46 +589,27 @@ mod tests {
                     let num_pixels = (naxis2 * naxis1) as usize;
 
                     let data = hdu_list.get_data(&hdu);
-                    match data.pixels() {
-                        Pixels::U8(it) => {
-                            let data = it.collect::<Vec<_>>();
-                            assert_eq!(num_pixels, data.len())
+                    assert_eq!(
+                        num_pixels,
+                        match data.pixels() {
+                            Pixels::U8(it) => it.count(),
+                            Pixels::I16(it) => it.count(),
+                            Pixels::I32(it) => it.count(),
+                            Pixels::I64(it) => it.count(),
+                            Pixels::F32(it) => it.count(),
+                            Pixels::F64(it) => it.count(),
                         }
-                        Pixels::I16(it) => {
-                            let data = it.collect::<Vec<_>>();
-                            assert_eq!(num_pixels, data.len())
-                        }
-                        Pixels::I32(it) => {
-                            let data = it.collect::<Vec<_>>();
-                            assert_eq!(num_pixels, data.len())
-                        }
-                        Pixels::I64(it) => {
-                            let data = it.collect::<Vec<_>>();
-                            assert_eq!(num_pixels, data.len())
-                        }
-                        Pixels::F32(it) => {
-                            let data = it.collect::<Vec<_>>();
-                            assert_eq!(num_pixels, data.len())
-                        }
-                        Pixels::F64(it) => {
-                            let data = it.collect::<Vec<_>>();
-                            assert_eq!(num_pixels, data.len())
-                        }
-                    }
+                    );
                 }
                 HDU::XBinaryTable(hdu) => {
                     let num_rows = hdu.get_header().get_xtension().get_num_rows();
 
-                    let rows = hdu_list.get_data(&hdu).row_iter().collect::<Vec<_>>();
-
-                    assert_eq!(num_rows, rows.len());
+                    assert_eq!(num_rows, hdu_list.get_data(&hdu).row_iter().count());
                 }
                 HDU::XASCIITable(hdu) => {
                     let num_bytes = hdu.get_header().get_xtension().get_num_bytes_data_block();
 
-                    let data = hdu_list.get_data(&hdu).bytes().collect::<Vec<_>>();
-
-                    assert_eq!(num_bytes as usize, data.len());
+                    assert_eq!(num_bytes as usize, hdu_list.get_data(&hdu).bytes().count());
                 }
             }
         }


### PR DESCRIPTION
- Replace `.collect()` with `.count()` in tests to reduce memory usage and simplify comparisons.
- Introduce a `get_num_pixels` helper method to calculate the total number of pixels in an image.