### PR TITLE
Serde integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ exclude = [
 [dependencies]
 byteorder = "1.4.2"
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = "1.0.138"
 futures = "0.3.31"
 async-trait = "0.1.66"
 quick-error = "2.0.1"
@@ -27,6 +26,7 @@ flate2 = "1.0.35"
 log = "0.4"
 wcs = "0.4.1"
 indexmap = { version = "2.9.0", features = ["serde"] }
+serde_repr = "0.1.20"
 
 [dev-dependencies]
 test-case = "3.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ quick-error = "2.0.1"
 flate2 = "1.0.35"
 log = "0.4"
 wcs = "0.4.1"
+indexmap = { version = "2.9.0", features = ["serde"] }
 
 [dev-dependencies]
 test-case = "3.0.0"

--- a/benches/decompress.rs
+++ b/benches/decompress.rs
@@ -32,16 +32,8 @@ fn decompress(filename: &str) {
 
     while let Some(Ok(hdu)) = hdu_list.next() {
         if let HDU::XBinaryTable(hdu) = hdu {
-            let width = hdu
-                .get_header()
-                .get_parsed::<i64>("ZNAXIS1")
-                .unwrap()
-                .unwrap() as u32;
-            let height = hdu
-                .get_header()
-                .get_parsed::<i64>("ZNAXIS2")
-                .unwrap()
-                .unwrap() as u32;
+            let width = hdu.get_header().get_parsed::<usize>("ZNAXIS1").unwrap();
+            let height = hdu.get_header().get_parsed::<usize>("ZNAXIS2").unwrap();
             let pixels = hdu_list.get_data(&hdu).collect::<Vec<_>>();
 
             assert!(width * height == pixels.len() as u32);
@@ -62,16 +54,8 @@ fn read_image() {
     while let Some(Ok(hdu)) = hdu_list.next() {
         match hdu {
             HDU::Primary(hdu) | HDU::XImage(hdu) => {
-                let width = hdu
-                    .get_header()
-                    .get_parsed::<i64>("NAXIS1")
-                    .unwrap()
-                    .unwrap() as u32;
-                let height = hdu
-                    .get_header()
-                    .get_parsed::<i64>("NAXIS2")
-                    .unwrap()
-                    .unwrap() as u32;
+                let width = hdu.get_header().get_parsed::<usize>("NAXIS1").unwrap();
+                let height = hdu.get_header().get_parsed::<usize>("NAXIS2").unwrap();
                 let pixels = match hdu_list.get_data(&hdu).pixels() {
                     Pixels::I16(it) => it.collect::<Vec<_>>(),
                     _ => unreachable!(),

--- a/benches/decompress.rs
+++ b/benches/decompress.rs
@@ -36,7 +36,7 @@ fn decompress(filename: &str) {
             let height = hdu.get_header().get_parsed::<usize>("ZNAXIS2").unwrap();
             let pixels = hdu_list.get_data(&hdu).collect::<Vec<_>>();
 
-            assert!(width * height == pixels.len() as u32);
+            assert!(width * height == pixels.len());
         }
     }
 }
@@ -61,7 +61,7 @@ fn read_image() {
                     _ => unreachable!(),
                 };
 
-                assert!(width * height == pixels.len() as u32);
+                assert!(width * height == pixels.len());
             }
             _ => (),
         }

--- a/fitswasm/Cargo.toml
+++ b/fitswasm/Cargo.toml
@@ -7,11 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wasm-bindgen = { version = "0.2.69", features = ["serde-serialize"]} 
+wasm-bindgen = { version = "0.2.69", features = ["serde-serialize"]}
 js-sys = "0.3.46"
 fitsrs = { path = './..' }
-serde = { version = "*", features = ["derive"] }
-serde_json = "1.0"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.19"

--- a/src/card.rs
+++ b/src/card.rs
@@ -167,7 +167,7 @@ fn parse_extension(buf: &[u8; 80]) -> Result<Card, Error> {
     let (value, comment) = split_value_and_comment(&buf[10..])?;
     if value.starts_with("'") && value.ends_with("'") {
         let end = value.len() - 1;
-        let x = XtensionType::try_from(value[1..end].trim_ascii())?;
+        let x = value[1..end].trim_ascii().parse()?;
         Ok(Card::Xtension { x, comment })
     } else {
         let msg = format!("XTENSION value must be enclosed in single quotes, found: {value}");

--- a/src/card.rs
+++ b/src/card.rs
@@ -379,28 +379,28 @@ fn parse_empty_keyword_card(buf: &[u8; 80]) -> Card {
 }
 
 pub trait CardValue {
-    fn parse(value: Value) -> Result<Self, Error>
+    fn parse(value: &Value) -> Result<Self, Error>
     where
         Self: Sized;
 }
 
 impl CardValue for f64 {
-    fn parse(value: Value) -> Result<Self, Error> {
+    fn parse(value: &Value) -> Result<Self, Error> {
         Value::check_for_float(value)
     }
 }
 impl CardValue for i64 {
-    fn parse(value: Value) -> Result<Self, Error> {
+    fn parse(value: &Value) -> Result<Self, Error> {
         Value::check_for_integer(value)
     }
 }
 impl CardValue for String {
-    fn parse(value: Value) -> Result<Self, Error> {
-        Value::check_for_string(value)
+    fn parse(value: &Value) -> Result<Self, Error> {
+        Value::check_for_string(value).map(|s| s.to_owned())
     }
 }
 impl CardValue for bool {
-    fn parse(value: Value) -> Result<Self, Error> {
+    fn parse(value: &Value) -> Result<Self, Error> {
         Value::check_for_boolean(value)
     }
 }
@@ -475,27 +475,27 @@ fn parse_unit(comment: &Option<String>) -> Option<&str> {
 }
 
 impl Value {
-    pub fn check_for_integer(self) -> Result<i64, Error> {
+    pub fn check_for_integer(&self) -> Result<i64, Error> {
         match self {
-            Value::Integer { value: num, .. } => Ok(num),
+            Value::Integer { value: num, .. } => Ok(*num),
             _ => Err(Error::ValueBadParsing),
         }
     }
-    pub fn check_for_boolean(self) -> Result<bool, Error> {
+    pub fn check_for_boolean(&self) -> Result<bool, Error> {
         match self {
-            Value::Logical { value: logical, .. } => Ok(logical),
+            Value::Logical { value: logical, .. } => Ok(*logical),
             _ => Err(Error::ValueBadParsing),
         }
     }
-    pub fn check_for_string(self) -> Result<String, Error> {
+    pub fn check_for_string(&self) -> Result<&str, Error> {
         match self {
             Value::String { value: s, .. } => Ok(s),
             _ => Err(Error::ValueBadParsing),
         }
     }
-    pub fn check_for_float(self) -> Result<f64, Error> {
+    pub fn check_for_float(&self) -> Result<f64, Error> {
         match self {
-            Value::Float { value: f, .. } => Ok(f),
+            Value::Float { value: f, .. } => Ok(*f),
             _ => Err(Error::ValueBadParsing),
         }
     }

--- a/src/card.rs
+++ b/src/card.rs
@@ -6,7 +6,8 @@ pub type Keyword = [u8; 8];
 /// Holds 80 bytes of ASCII characters, i.e. one line in a FITS compliant file.
 pub type CardBuf = [u8; 80];
 
-use serde::Serialize;
+use serde::de::IntoDeserializer;
+use serde::{forward_to_deserialize_any, Deserializer, Serialize};
 
 /// Enum representing the variants of a single 80 character line in the header.
 #[derive(PartialEq, Debug, Serialize, Clone)]
@@ -378,33 +379,6 @@ fn parse_empty_keyword_card(buf: &[u8; 80]) -> Card {
     }
 }
 
-pub trait CardValue {
-    fn parse(value: &Value) -> Result<Self, Error>
-    where
-        Self: Sized;
-}
-
-impl CardValue for f64 {
-    fn parse(value: &Value) -> Result<Self, Error> {
-        Value::check_for_float(value)
-    }
-}
-impl CardValue for i64 {
-    fn parse(value: &Value) -> Result<Self, Error> {
-        Value::check_for_integer(value)
-    }
-}
-impl CardValue for String {
-    fn parse(value: &Value) -> Result<Self, Error> {
-        Value::check_for_string(value).map(|s| s.to_owned())
-    }
-}
-impl CardValue for bool {
-    fn parse(value: &Value) -> Result<Self, Error> {
-        Value::check_for_boolean(value)
-    }
-}
-
 /// Enum structure corresponding to all the possible types of cards in a header.
 #[derive(Debug, PartialEq, Clone, Serialize)]
 pub enum Value {
@@ -454,6 +428,49 @@ impl Value {
     }
 }
 
+impl<'de> Deserializer<'de> for &'de Value {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        match self {
+            Value::Integer { value, comment: _ } => visitor.visit_i64(*value),
+            Value::Float { value, comment: _ } => visitor.visit_f64(*value),
+            Value::Logical { value, comment: _ } => visitor.visit_bool(*value),
+            Value::String { value, comment: _ } => visitor.visit_borrowed_str(value),
+            Value::Undefined => visitor.visit_unit(),
+            Value::Invalid(s) => visitor.visit_borrowed_str(s),
+        }
+    }
+
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        if self == &Value::Undefined {
+            visitor.visit_none()
+        } else {
+            visitor.visit_some(self)
+        }
+    }
+
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 u8 u16 u32 u64 f32 f64 char str string bytes byte_buf unit
+        seq tuple tuple_struct map struct enum identifier ignored_any
+        newtype_struct unit_struct
+    }
+}
+
+impl<'de> IntoDeserializer<'de, Error> for &'de Value {
+    type Deserializer = Self;
+
+    fn into_deserializer(self) -> Self::Deserializer {
+        self
+    }
+}
+
 /// Return the unit enclosed in brackets of the a comment, returns None
 /// if there is no comment or no unit in brackets.
 ///
@@ -475,31 +492,6 @@ fn parse_unit(comment: &Option<String>) -> Option<&str> {
 }
 
 impl Value {
-    pub fn check_for_integer(&self) -> Result<i64, Error> {
-        match self {
-            Value::Integer { value: num, .. } => Ok(*num),
-            _ => Err(Error::ValueBadParsing),
-        }
-    }
-    pub fn check_for_boolean(&self) -> Result<bool, Error> {
-        match self {
-            Value::Logical { value: logical, .. } => Ok(*logical),
-            _ => Err(Error::ValueBadParsing),
-        }
-    }
-    pub fn check_for_string(&self) -> Result<&str, Error> {
-        match self {
-            Value::String { value: s, .. } => Ok(s),
-            _ => Err(Error::ValueBadParsing),
-        }
-    }
-    pub fn check_for_float(&self) -> Result<f64, Error> {
-        match self {
-            Value::Float { value: f, .. } => Ok(*f),
-            _ => Err(Error::ValueBadParsing),
-        }
-    }
-
     pub fn append(&mut self, v: &Option<String>, c: &Option<String>) -> &mut Self {
         if let Value::String { value, comment } = self {
             append_string(value, v);

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,9 +10,6 @@ quick_error! {
             from()
             display("{message}")
         }
-        BitpixBadValue {
-            display("Bitpix value found is not valid. Standard values are: -64, -32, 8, 16, 32 and 64.")
-        }
         /// Fits file is not a multiple of 80 bytes long
         FailReadingNextBytes {
             display("A 80 bytes card could not be read. A fits file must have a multiple of 80 characters.")
@@ -23,12 +20,6 @@ quick_error! {
         WCS {
             from(wcs::error::Error)
             display("WCS parsing")
-        }
-        ValueBadParsing {
-            display("A value could not be parsed correctly")
-        }
-        FailTypeCardParsing(card: String, t: String) {
-            display("{card} card is not of type {t}")
         }
         NotSupportedXtensionType(extension: String) {
             display("{extension} extension is not supported. Only BINTABLE, TABLE and IMAGE are.")
@@ -44,5 +35,11 @@ quick_error! {
             // to only store its error kind which is sufficiant for our use
             from(err: std::io::Error) -> (err.kind())
         }
+    }
+}
+
+impl serde::de::Error for Error {
+    fn custom<T: std::fmt::Display>(msg: T) -> Self {
+        Error::DynamicError(msg.to_string())
     }
 }

--- a/src/fits.rs
+++ b/src/fits.rs
@@ -8,7 +8,7 @@ use crate::hdu::header::Xtension;
 
 use std::fmt::Debug;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Fits<R> {
     start: bool,
     // Store the number of bytes that remains to read so that the current HDU data finishes
@@ -29,21 +29,6 @@ where
 {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         self.reader.read(buf)
-    }
-}
-
-impl<R> Clone for Fits<R>
-where
-    R: Clone,
-{
-    fn clone(&self) -> Self {
-        Self {
-            reader: self.reader.clone(),
-            error_parsing_encountered: self.error_parsing_encountered,
-            num_bytes_in_cur_du: self.num_bytes_in_cur_du,
-            pos_start_cur_du: self.pos_start_cur_du,
-            start: self.start,
-        }
     }
 }
 

--- a/src/hdu/data/bintable/tile_compressed.rs
+++ b/src/hdu/data/bintable/tile_compressed.rs
@@ -200,14 +200,15 @@ impl<R> TileCompressedData<R> {
             // If no ZBLANK colum has been found then check the header keywords (ZBLANK for float, BLANK for integer)
             .map_or_else(
                 || {
-                    if (*z_bitpix as i32) < 0 {
-                        header.get_parsed("ZBLANK")
-                    } else {
-                        header.get_parsed("BLANK").map(|value: i64| value as f64)
-                    }
-                    // TODO: we should probably propagate errors from here if ZBLANK/BLANK exist but are of a wrong type.
-                    .ok()
-                    .map(ZBLANK::Value)
+                    header
+                        .get_parsed(if (*z_bitpix as i32) < 0 {
+                            "ZBLANK"
+                        } else {
+                            "BLANK"
+                        })
+                        // TODO: we should probably propagate errors from here if ZBLANK/BLANK exist but are of a wrong type.
+                        .ok()
+                        .map(ZBLANK::Value)
                 },
                 |field_idx| Some(ZBLANK::ColumnIdx(field_idx)),
             );
@@ -601,16 +602,8 @@ mod tests {
 
         while let Some(Ok(hdu)) = hdu_list.next() {
             if let HDU::XBinaryTable(hdu) = hdu {
-                let width = hdu
-                    .get_header()
-                    .get_parsed::<i64>("ZNAXIS1")
-                    .unwrap()
-                    .unwrap() as u32;
-                let height = hdu
-                    .get_header()
-                    .get_parsed::<i64>("ZNAXIS2")
-                    .unwrap()
-                    .unwrap() as u32;
+                let width = hdu.get_header().get_parsed::<u32>("ZNAXIS1").unwrap();
+                let height = hdu.get_header().get_parsed::<u32>("ZNAXIS2").unwrap();
                 let pixels = hdu_list
                     .get_data(&hdu)
                     .map(|value| match value {
@@ -645,26 +638,10 @@ mod tests {
 
         while let Some(Ok(hdu)) = hdu_list.next() {
             if let HDU::XBinaryTable(hdu) = hdu {
-                let width = hdu
-                    .get_header()
-                    .get_parsed::<i64>("ZNAXIS1")
-                    .unwrap()
-                    .unwrap() as u32;
-                let height = hdu
-                    .get_header()
-                    .get_parsed::<i64>("ZNAXIS2")
-                    .unwrap()
-                    .unwrap() as u32;
-                let bscale = hdu
-                    .get_header()
-                    .get_parsed::<f64>("BSCALE")
-                    .unwrap()
-                    .unwrap() as f32;
-                let bzero = hdu
-                    .get_header()
-                    .get_parsed::<f64>("BZERO")
-                    .unwrap()
-                    .unwrap() as f32;
+                let width = hdu.get_header().get_parsed::<u32>("ZNAXIS1").unwrap();
+                let height = hdu.get_header().get_parsed::<u32>("ZNAXIS2").unwrap();
+                let bscale = hdu.get_header().get_parsed::<f32>("BSCALE").unwrap();
+                let bzero = hdu.get_header().get_parsed::<f32>("BZERO").unwrap();
 
                 let pixels = hdu_list
                     .get_data(&hdu)
@@ -701,16 +678,8 @@ mod tests {
 
         while let Some(Ok(hdu)) = hdu_list.next() {
             if let HDU::XBinaryTable(hdu) = hdu {
-                let width = hdu
-                    .get_header()
-                    .get_parsed::<i64>("ZNAXIS1")
-                    .unwrap()
-                    .unwrap() as u32;
-                let height = hdu
-                    .get_header()
-                    .get_parsed::<i64>("ZNAXIS2")
-                    .unwrap()
-                    .unwrap() as u32;
+                let width = hdu.get_header().get_parsed::<u32>("ZNAXIS1").unwrap();
+                let height = hdu.get_header().get_parsed::<u32>("ZNAXIS2").unwrap();
 
                 let mut buf = vec![0_u8; (width as usize) * (height as usize)];
 

--- a/src/hdu/header/extension/asciitable.rs
+++ b/src/hdu/header/extension/asciitable.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use async_trait::async_trait;
 
 use log::warn;
@@ -16,6 +14,7 @@ use crate::hdu::header::check_for_pcount;
 use crate::hdu::header::check_for_tfields;
 use crate::hdu::header::Bitpix;
 
+use crate::hdu::header::ValueMap;
 use crate::hdu::header::Xtension;
 use std::num::ParseIntError;
 use std::str::FromStr;
@@ -107,7 +106,7 @@ impl Xtension for AsciiTable {
         self.naxis1 * self.naxis2
     }
 
-    fn parse(values: &HashMap<String, Value>) -> Result<Self, Error> {
+    fn parse(values: &ValueMap) -> Result<Self, Error> {
         // BITPIX
         let bitpix = check_for_bitpix(values)?;
         if bitpix != Bitpix::U8 {

--- a/src/hdu/header/extension/asciitable.rs
+++ b/src/hdu/header/extension/asciitable.rs
@@ -5,12 +5,6 @@ use serde::Serialize;
 
 use crate::error::Error;
 
-use crate::hdu::header::check_for_bitpix;
-use crate::hdu::header::check_for_gcount;
-use crate::hdu::header::check_for_naxis;
-use crate::hdu::header::check_for_naxisi;
-use crate::hdu::header::check_for_pcount;
-use crate::hdu::header::check_for_tfields;
 use crate::hdu::header::Bitpix;
 
 use crate::hdu::header::ValueMap;
@@ -106,35 +100,35 @@ impl Xtension for AsciiTable {
 
     fn parse(values: &ValueMap) -> Result<Self, Error> {
         // BITPIX
-        let bitpix = check_for_bitpix(values)?;
+        let bitpix = values.check_for_bitpix()?;
         if bitpix != Bitpix::U8 {
             return Err(Error::StaticError("Ascii Table HDU must have a BITPIX = 8"));
         }
 
         // NAXIS
-        let naxis = check_for_naxis(values)?;
+        let naxis = values.check_for_naxis()?;
         if naxis != 2 {
             return Err(Error::StaticError("Ascii Table HDU must have NAXIS = 2"));
         }
 
         // NAXIS1
-        let naxis1 = check_for_naxisi(values, 1)?;
-        let naxis2 = check_for_naxisi(values, 2)?;
+        let naxis1 = values.check_for_naxisi(1)?;
+        let naxis2 = values.check_for_naxisi(2)?;
 
         // PCOUNT
-        let pcount = check_for_pcount(values)?;
+        let pcount = values.check_for_pcount()?;
         if pcount != 0 {
             return Err(Error::StaticError("Ascii Table HDU must have PCOUNT = 0"));
         }
 
         // GCOUNT
-        let gcount = check_for_gcount(values)?;
+        let gcount = values.check_for_gcount()?;
         if gcount != 1 {
             return Err(Error::StaticError("Ascii Table HDU must have GCOUNT = 1"));
         }
 
         // FIELDS
-        let tfields = check_for_tfields(values)?;
+        let tfields = values.check_for_tfields()?;
 
         // TFORMS
         let mut tbcols = Vec::with_capacity(tfields);

--- a/src/hdu/header/extension/asciitable.rs
+++ b/src/hdu/header/extension/asciitable.rs
@@ -13,10 +13,9 @@ use crate::hdu::header::check_for_pcount;
 use crate::hdu::header::check_for_tfields;
 use crate::hdu::header::Bitpix;
 
-use crate::card::CardValue;
-use crate::card::Value;
 use crate::hdu::header::ValueMap;
 use crate::hdu::header::Xtension;
+use serde::Deserialize;
 
 #[derive(Debug, PartialEq, Serialize, Clone)]
 pub struct AsciiTable {
@@ -141,7 +140,7 @@ impl Xtension for AsciiTable {
         let mut tbcols = Vec::with_capacity(tfields);
         let mut tforms = Vec::with_capacity(tfields);
         for idx_field in 1..=tfields {
-            let tbcol = match values.get_parsed::<i64>(&format!("TBCOL{idx_field}")) {
+            let tbcol = match values.get_parsed(&format!("TBCOL{idx_field}")) {
                 Ok(tbcol) => tbcol,
                 Err(err) => {
                     warn!("Discard field {idx_field}: {err}");
@@ -149,7 +148,7 @@ impl Xtension for AsciiTable {
                 }
             };
 
-            let tform = match values.get_parsed::<TFormAsciiTable>(&format!("TFORM{idx_field}")) {
+            let tform = match values.get_parsed(&format!("TFORM{idx_field}")) {
                 Ok(tform) => tform,
                 Err(err) => {
                     warn!("Discard field {idx_field}: {err}");
@@ -157,7 +156,7 @@ impl Xtension for AsciiTable {
                 }
             };
 
-            tbcols.push(tbcol as _);
+            tbcols.push(tbcol);
             tforms.push(tform);
         }
 
@@ -192,55 +191,80 @@ pub enum TFormAsciiTable {
     DFloatingPointExp { w: usize, d: usize },
 }
 
-impl CardValue for TFormAsciiTable {
-    fn parse(value: &Value) -> Result<Self, Error> {
-        let mut chars = value.check_for_string()?.trim_end().chars();
-        let first_char = chars
-            .next()
-            .ok_or(Error::StaticError("TFORM string is empty"))?;
-        let rest = chars.as_str();
+impl<'de> Deserialize<'de> for TFormAsciiTable {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
 
-        let parse = |s: &str| {
-            s.parse()
-                .map_err(|_| Error::StaticError("Failed to parse an integer from the TFORM string"))
-        };
+        impl serde::de::Visitor<'_> for Visitor {
+            type Value = TFormAsciiTable;
 
-        let parse_split = || {
-            let (w, d) = rest.split_once('.').ok_or(Error::StaticError(
-                "Expected to find `.` in the TFORM string",
-            ))?;
-
-            Ok::<_, Error>((parse(w)?, parse(d)?))
-        };
-
-        Ok(match first_char {
-            'A' => {
-                let w = parse(rest)?;
-
-                TFormAsciiTable::Character { w }
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a valid TFORM string")
             }
-            'I' => {
-                let w = parse(rest)?;
 
-                TFormAsciiTable::DecimalInteger { w }
-            }
-            'F' => {
-                let (w, d) = parse_split()?;
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                let mut chars = v.trim_end().chars();
+                let first_char = chars.next().ok_or(E::custom("TFORM string is empty"))?;
+                let rest = chars.as_str();
 
-                TFormAsciiTable::FloatingPointFixed { w, d }
-            }
-            'E' => {
-                let (w, d) = parse_split()?;
+                let parse = |s: &str| {
+                    s.parse().map_err(|err| {
+                        E::custom(format_args!(
+                            "Failed to parse an integer from the TFORM string: {err}"
+                        ))
+                    })
+                };
 
-                TFormAsciiTable::EFloatingPointExp { w, d }
-            }
-            'D' => {
-                let (w, d) = parse_split()?;
+                let parse_split = || {
+                    let (w, d) = rest
+                        .split_once('.')
+                        .ok_or(E::custom("Expected to find `.` in the TFORM string"))?;
 
-                TFormAsciiTable::DFloatingPointExp { w, d }
+                    Ok::<_, E>((parse(w)?, parse(d)?))
+                };
+
+                Ok(match first_char {
+                    'A' => {
+                        let w = parse(rest)?;
+
+                        TFormAsciiTable::Character { w }
+                    }
+                    'I' => {
+                        let w = parse(rest)?;
+
+                        TFormAsciiTable::DecimalInteger { w }
+                    }
+                    'F' => {
+                        let (w, d) = parse_split()?;
+
+                        TFormAsciiTable::FloatingPointFixed { w, d }
+                    }
+                    'E' => {
+                        let (w, d) = parse_split()?;
+
+                        TFormAsciiTable::EFloatingPointExp { w, d }
+                    }
+                    'D' => {
+                        let (w, d) = parse_split()?;
+
+                        TFormAsciiTable::DFloatingPointExp { w, d }
+                    }
+                    _ => {
+                        return Err(E::custom(format_args!(
+                            "Invalid TFORM prefix '{first_char}'"
+                        )))
+                    }
+                })
             }
-            _ => return Err(Error::StaticError("Invalid TFORM prefix")),
-        })
+        }
+
+        deserializer.deserialize_str(Visitor)
     }
 }
 

--- a/src/hdu/header/extension/asciitable.rs
+++ b/src/hdu/header/extension/asciitable.rs
@@ -3,7 +3,6 @@ use async_trait::async_trait;
 use log::warn;
 use serde::Serialize;
 
-use crate::card::Value;
 use crate::error::Error;
 
 use crate::hdu::header::check_for_bitpix;
@@ -14,10 +13,10 @@ use crate::hdu::header::check_for_pcount;
 use crate::hdu::header::check_for_tfields;
 use crate::hdu::header::Bitpix;
 
+use crate::card::CardValue;
+use crate::card::Value;
 use crate::hdu::header::ValueMap;
 use crate::hdu::header::Xtension;
-use std::num::ParseIntError;
-use std::str::FromStr;
 
 #[derive(Debug, PartialEq, Serialize, Clone)]
 pub struct AsciiTable {
@@ -139,29 +138,28 @@ impl Xtension for AsciiTable {
         let tfields = check_for_tfields(values)?;
 
         // TFORMS
-        let (tbcols, tforms) = (1..=tfields)
-            .filter_map(|idx_field| {
-                let tbcol = if let Some(Value::Integer { value, .. }) =
-                    values.get(&format!("TBCOL{idx_field}"))
-                {
-                    *value as u64
-                } else {
-                    warn!("Discard field {idx_field}");
-                    return None;
-                };
+        let mut tbcols = Vec::with_capacity(tfields);
+        let mut tforms = Vec::with_capacity(tfields);
+        for idx_field in 1..=tfields {
+            let tbcol = match values.get_parsed::<i64>(&format!("TBCOL{idx_field}")) {
+                Ok(tbcol) => tbcol,
+                Err(err) => {
+                    warn!("Discard field {idx_field}: {err}");
+                    continue;
+                }
+            };
 
-                let tform = if let Some(Value::String { value, .. }) =
-                    values.get(&format!("TFORM{idx_field}"))
-                {
-                    TFormAsciiTable::from_str(value).ok()?
-                } else {
-                    warn!("Discard field {idx_field}");
-                    return None;
-                };
+            let tform = match values.get_parsed::<TFormAsciiTable>(&format!("TFORM{idx_field}")) {
+                Ok(tform) => tform,
+                Err(err) => {
+                    warn!("Discard field {idx_field}: {err}");
+                    continue;
+                }
+            };
 
-                Some((tbcol, tform))
-            })
-            .unzip();
+            tbcols.push(tbcol as _);
+            tforms.push(tform);
+        }
 
         Ok(AsciiTable {
             bitpix,
@@ -194,47 +192,35 @@ pub enum TFormAsciiTable {
     DFloatingPointExp { w: usize, d: usize },
 }
 
-#[derive(Debug)]
-pub enum TFormAsciiTableParseError {
-    ParseInt(ParseIntError),
-    StringFormat,
-}
-
-impl From<ParseIntError> for TFormAsciiTableParseError {
-    fn from(err: ParseIntError) -> Self {
-        TFormAsciiTableParseError::ParseInt(err)
-    }
-}
-
-impl FromStr for TFormAsciiTable {
-    type Err = TFormAsciiTableParseError;
-
-    fn from_str(tform: &str) -> Result<Self, Self::Err> {
-        let mut chars = tform.trim_end().chars();
+impl CardValue for TFormAsciiTable {
+    fn parse(value: &Value) -> Result<Self, Error> {
+        let mut chars = value.check_for_string()?.trim_end().chars();
         let first_char = chars
             .next()
-            .ok_or(TFormAsciiTableParseError::StringFormat)?;
+            .ok_or(Error::StaticError("TFORM string is empty"))?;
         let rest = chars.as_str();
 
+        let parse = |s: &str| {
+            s.parse()
+                .map_err(|_| Error::StaticError("Failed to parse an integer from the TFORM string"))
+        };
+
         let parse_split = || {
-            let (w, d) = rest
-                .split_once('.')
-                .ok_or(TFormAsciiTableParseError::StringFormat)?;
+            let (w, d) = rest.split_once('.').ok_or(Error::StaticError(
+                "Expected to find `.` in the TFORM string",
+            ))?;
 
-            let w = w.parse()?;
-            let d = d.parse()?;
-
-            Ok::<_, Self::Err>((w, d))
+            Ok::<_, Error>((parse(w)?, parse(d)?))
         };
 
         Ok(match first_char {
             'A' => {
-                let w = rest.parse()?;
+                let w = parse(rest)?;
 
                 TFormAsciiTable::Character { w }
             }
             'I' => {
-                let w = rest.parse()?;
+                let w = parse(rest)?;
 
                 TFormAsciiTable::DecimalInteger { w }
             }
@@ -253,7 +239,7 @@ impl FromStr for TFormAsciiTable {
 
                 TFormAsciiTable::DFloatingPointExp { w, d }
             }
-            _ => return Err(TFormAsciiTableParseError::StringFormat),
+            _ => return Err(Error::StaticError("Invalid TFORM prefix")),
         })
     }
 }

--- a/src/hdu/header/extension/bintable.rs
+++ b/src/hdu/header/extension/bintable.rs
@@ -290,7 +290,7 @@ impl Xtension for BinTable {
             let mut z_tilen = Vec::with_capacity(z_naxis);
 
             for i in 1..=z_naxis {
-                let naxisn = if let Ok(value) = values.get_parsed::<i64>(&format!("ZNAXIS{i}")) {
+                let naxisn = if let Ok(value) = values.check_for_naxisi(i) {
                     value
                 } else {
                     warn!("ZNAXISN is mandatory. Tile compressed image discarded");

--- a/src/hdu/header/extension/bintable.rs
+++ b/src/hdu/header/extension/bintable.rs
@@ -236,8 +236,8 @@ impl Xtension for BinTable {
                                 if value == "BLOCKSIZE" && zname.starts_with("ZNAME") {
                                     let zval = zname.replace("NAME", "VAL");
 
-                                    if let Some(Value::Integer { value, .. }) = values.get(&zval) {
-                                        Some(*value as u8)
+                                    if let Ok(value) = values.get_parsed::<i64>(&zval) {
+                                        Some(value as u8)
                                     } else {
                                         None
                                     }
@@ -267,30 +267,19 @@ impl Xtension for BinTable {
             None
         };
 
-        let z_bitpix = if let Some(Value::Integer {
-            value: z_bitpix, ..
-        }) = values.get("ZBITPIX")
-        {
-            match z_bitpix {
-                8 => Some(Bitpix::U8),
-                16 => Some(Bitpix::I16),
-                32 => Some(Bitpix::I32),
-                64 => Some(Bitpix::I64),
-                -32 => Some(Bitpix::F32),
-                -64 => Some(Bitpix::F64),
-                _ => {
-                    warn!("ZBITPIX is not valid. The tile compressed image column will be discarded if any");
-                    None
-                }
+        let z_bitpix = match values.try_get_parsed::<Bitpix>("ZBITPIX") {
+            Ok(Some(z_bitpix)) => Some(z_bitpix),
+            Ok(None) => None,
+            Err(err) => {
+                warn!("ZBITPIX is not valid. The tile compressed image column will be discarded if any: {}", err);
+                None
             }
-        } else {
-            None
         };
 
         // ZNAXIS (required keyword) The value field of this keyword shall contain an integer that gives
         // the value of the NAXIS keyword in the uncompressed FITS image.
-        let z_naxis = if let Some(Value::Integer { value, .. }) = values.get("ZNAXIS") {
-            Some(*value as usize)
+        let z_naxis = if let Ok(value) = values.get_parsed::<i64>("ZNAXIS") {
+            Some(value as usize)
         } else {
             None
         };
@@ -315,23 +304,24 @@ impl Xtension for BinTable {
             let mut z_tilen = Vec::with_capacity(z_naxis);
 
             for i in 1..=z_naxis {
-                let naxisn =
-                    if let Some(Value::Integer { value, .. }) = values.get(&format!("ZNAXIS{i}")) {
-                        *value
-                    } else {
-                        warn!("ZNAXISN is mandatory. Tile compressed image discarded");
-                        break;
-                    };
+                let naxisn = if let Ok(value) = values.get_parsed::<i64>(&format!("ZNAXIS{i}")) {
+                    value
+                } else {
+                    warn!("ZNAXISN is mandatory. Tile compressed image discarded");
+                    break;
+                };
 
                 // If not found, z_tilen equals z_naxisn
-                let tilen = match (values.get(&format!("ZTILE{i}")), i) {
+                let tilen = if let Ok(value) = values.get_parsed(&format!("ZTILE{i}")) {
                     // ZTILEi has been found
-                    (Some(&Value::Integer { value, .. }), _) => value,
+                    value
+                } else if i == 1 {
                     // ZTILEi has not been found or is not set to an integer => default behavior
                     // * i == 1, ZTILE1 = NAXIS1
+                    naxisn
+                } else {
                     // * i > 1, ZTILEi = 1
-                    (_, 1) => naxisn,
-                    _ => 1,
+                    1
                 };
 
                 z_naxisn.push(naxisn as usize);
@@ -374,8 +364,8 @@ impl Xtension for BinTable {
         // gives the seed value for the random dithering pattern that was used when quantizing the
         // floating-point pixel values. The value may range from 1 to 10000, inclusive. See section 4 for
         // further discussion of this keyword.
-        let z_dither_0 = if let Some(Value::Integer { value, .. }) = values.get("ZDITHER0") {
-            Some(*value)
+        let z_dither_0 = if let Ok(value) = values.get_parsed("ZDITHER0") {
+            Some(value)
         } else {
             None
         };
@@ -385,7 +375,7 @@ impl Xtension for BinTable {
             .filter_map(|idx_field| {
                 // discard the tform if it was not found and raise a warning
                 let tform_kw = format!("TFORM{idx_field}");
-                let tform = if let Some(Value::String{value, ..}) = values.get(&tform_kw) {
+                let tform = if let Ok(value) = values.get_parsed(&tform_kw) {
                     Some(value)
                 } else {
                     warn!("{tform_kw} has not been found. It will be discarded");
@@ -393,8 +383,8 @@ impl Xtension for BinTable {
                 }?;
 
                 // try to find a ttype (optional keyword)
-                let ttype = if let Some(Value::String{value, ..}) = values.get(&format!("TTYPE{idx_field}")) {
-                    Some(value.to_owned())
+                let ttype = if let Ok(value) = values.get_parsed(&format!("TTYPE{idx_field}")) {
+                    Some(value)
                 } else {
                     warn!("Field {tform_kw:?} does not have a TTYPE name.");
                     None
@@ -549,8 +539,8 @@ impl Xtension for BinTable {
         };
 
         // update the value of theap if found
-        let theap = if let Some(Value::Integer { value, .. }) = values.get("THEAP") {
-            *value as usize
+        let theap = if let Ok(value) = values.get_parsed("THEAP") {
+            value as usize
         } else {
             (naxis1 as usize) * (naxis2 as usize)
         };

--- a/src/hdu/header/extension/bintable.rs
+++ b/src/hdu/header/extension/bintable.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::fmt::Debug;
 
 use crate::error::Error;
@@ -15,6 +14,7 @@ use serde::Serialize;
 
 use super::Xtension;
 
+use crate::hdu::header::ValueMap;
 use log::warn;
 
 #[derive(Debug, PartialEq, Serialize, Clone)]
@@ -186,7 +186,7 @@ impl Xtension for BinTable {
         self.naxis1 * self.naxis2 + self.pcount
     }
 
-    fn parse(values: &HashMap<String, Value>) -> Result<Self, Error> {
+    fn parse(values: &ValueMap) -> Result<Self, Error> {
         // BITPIX
         let bitpix = check_for_bitpix(values)?;
         if bitpix != Bitpix::U8 {
@@ -374,12 +374,11 @@ impl Xtension for BinTable {
         // gives the seed value for the random dithering pattern that was used when quantizing the
         // floating-point pixel values. The value may range from 1 to 10000, inclusive. See section 4 for
         // further discussion of this keyword.
-        let z_dither_0 =
-            if let Some(Value::Integer { value, .. }) = values.get(&"ZDITHER0".to_string()) {
-                Some(*value)
-            } else {
-                None
-            };
+        let z_dither_0 = if let Some(Value::Integer { value, .. }) = values.get("ZDITHER0") {
+            Some(*value)
+        } else {
+            None
+        };
 
         // TFORMS & TTYPES
         let (tforms, ttypes): (Vec<_>, Vec<_>) = (1..=tfields)

--- a/src/hdu/header/extension/bintable.rs
+++ b/src/hdu/header/extension/bintable.rs
@@ -1,12 +1,6 @@
 use std::fmt::Debug;
 
 use crate::error::Error;
-use crate::hdu::header::check_for_bitpix;
-use crate::hdu::header::check_for_gcount;
-use crate::hdu::header::check_for_naxis;
-use crate::hdu::header::check_for_naxisi;
-use crate::hdu::header::check_for_pcount;
-use crate::hdu::header::check_for_tfields;
 use crate::hdu::header::Bitpix;
 use crate::hdu::Value;
 use async_trait::async_trait;
@@ -192,7 +186,7 @@ impl Xtension for BinTable {
 
     fn parse(values: &ValueMap) -> Result<Self, Error> {
         // BITPIX
-        let bitpix = check_for_bitpix(values)?;
+        let bitpix = values.check_for_bitpix()?;
         if bitpix != Bitpix::U8 {
             return Err(Error::StaticError(
                 "Binary Table HDU must have a BITPIX = 8",
@@ -200,27 +194,27 @@ impl Xtension for BinTable {
         }
 
         // NAXIS
-        let naxis = check_for_naxis(values)?;
+        let naxis = values.check_for_naxis()?;
         if naxis != 2 {
             return Err(Error::StaticError("Binary Table HDU must have NAXIS = 2"));
         }
 
         // NAXIS1
-        let naxis1 = check_for_naxisi(values, 1)?;
+        let naxis1 = values.check_for_naxisi(1)?;
         // NAXIS2
-        let naxis2 = check_for_naxisi(values, 2)?;
+        let naxis2 = values.check_for_naxisi(2)?;
 
         // PCOUNT
-        let pcount = check_for_pcount(values)?;
+        let pcount = values.check_for_pcount()?;
 
         // GCOUNT
-        let gcount = check_for_gcount(values)?;
+        let gcount = values.check_for_gcount()?;
         if gcount != 1 {
             return Err(Error::StaticError("Ascii Table HDU must have GCOUNT = 1"));
         }
 
         // FIELDS
-        let tfields = check_for_tfields(values)?;
+        let tfields = values.check_for_tfields()?;
 
         // Tile compressed image parameters
         let z_cmp_type = if let Some(Value::String {

--- a/src/hdu/header/extension/bintable.rs
+++ b/src/hdu/header/extension/bintable.rs
@@ -364,18 +364,14 @@ impl Xtension for BinTable {
         // gives the seed value for the random dithering pattern that was used when quantizing the
         // floating-point pixel values. The value may range from 1 to 10000, inclusive. See section 4 for
         // further discussion of this keyword.
-        let z_dither_0 = if let Ok(value) = values.get_parsed("ZDITHER0") {
-            Some(value)
-        } else {
-            None
-        };
+        let z_dither_0 = values.get_parsed("ZDITHER0").ok();
 
         // TFORMS & TTYPES
         let (tforms, ttypes): (Vec<_>, Vec<_>) = (1..=tfields)
             .filter_map(|idx_field| {
                 // discard the tform if it was not found and raise a warning
                 let tform_kw = format!("TFORM{idx_field}");
-                let tform = if let Ok(value) = values.get_parsed(&tform_kw) {
+                let tform = if let Ok(value) = values.get_parsed::<String>(&tform_kw) {
                     Some(value)
                 } else {
                     warn!("{tform_kw} has not been found. It will be discarded");
@@ -539,7 +535,7 @@ impl Xtension for BinTable {
         };
 
         // update the value of theap if found
-        let theap = if let Ok(value) = values.get_parsed("THEAP") {
+        let theap = if let Ok(value) = values.get_parsed::<i64>("THEAP") {
             value as usize
         } else {
             (naxis1 as usize) * (naxis2 as usize)

--- a/src/hdu/header/extension/bintable.rs
+++ b/src/hdu/header/extension/bintable.rs
@@ -16,6 +16,7 @@ use super::Xtension;
 
 use crate::hdu::header::ValueMap;
 use log::warn;
+use serde::Deserialize;
 
 #[derive(Debug, PartialEq, Serialize, Clone)]
 pub struct BinTable {
@@ -142,10 +143,13 @@ pub(crate) struct TileCompressedImage {
     pub(crate) data_compressed_idx: usize,
 }
 
-#[derive(Debug, PartialEq, Serialize, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub(crate) enum ZQuantiz {
+    #[serde(rename = "NO_DITHER")]
     NoDither,
+    #[serde(rename = "SUBTRACTIVE_DITHER_1")]
     SubtractiveDither1,
+    #[serde(rename = "SUBTRACTIVE_DITHER_2")]
     SubtractiveDither2,
 }
 
@@ -236,11 +240,7 @@ impl Xtension for BinTable {
                                 if value == "BLOCKSIZE" && zname.starts_with("ZNAME") {
                                     let zval = zname.replace("NAME", "VAL");
 
-                                    if let Ok(value) = values.get_parsed::<i64>(&zval) {
-                                        Some(value as u8)
-                                    } else {
-                                        None
-                                    }
+                                    values.get_parsed(&zval).ok()
                                 } else {
                                     None
                                 }
@@ -267,22 +267,14 @@ impl Xtension for BinTable {
             None
         };
 
-        let z_bitpix = match values.try_get_parsed::<Bitpix>("ZBITPIX") {
-            Ok(Some(z_bitpix)) => Some(z_bitpix),
-            Ok(None) => None,
-            Err(err) => {
-                warn!("ZBITPIX is not valid. The tile compressed image column will be discarded if any: {}", err);
-                None
-            }
-        };
+        let z_bitpix = values.get_parsed("ZBITPIX").unwrap_or_else(|err| {
+            warn!("ZBITPIX is not valid. The tile compressed image column will be discarded if any: {}", err);
+            None
+        });
 
         // ZNAXIS (required keyword) The value field of this keyword shall contain an integer that gives
         // the value of the NAXIS keyword in the uncompressed FITS image.
-        let z_naxis = if let Ok(value) = values.get_parsed::<i64>("ZNAXIS") {
-            Some(value as usize)
-        } else {
-            None
-        };
+        let z_naxis = values.get_parsed("ZNAXIS").ok();
 
         // ZNAXISn (required keywords) The value field of these keywords shall contain a positive integer
         // that gives the value of the NAXISn keywords in the uncompressed FITS image.
@@ -343,22 +335,10 @@ impl Xtension for BinTable {
         // ZQUANTIZ (optional keyword) This keyword records the name of the algorithm that was
         // used to quantize floating-point image pixels into integer values which are then passed to
         // the compression algorithm, as discussed further in section 4 of this document.
-        let z_quantiz = if let Some(Value::String {
-            value: z_quantiz, ..
-        }) = values.get("ZQUANTIZ")
-        {
-            match z_quantiz.trim_ascii_end() {
-                "NO_DITHER" => Some(ZQuantiz::NoDither),
-                "SUBTRACTIVE_DITHER_1" => Some(ZQuantiz::SubtractiveDither1),
-                "SUBTRACTIVE_DITHER_2" => Some(ZQuantiz::SubtractiveDither2),
-                _ => {
-                    warn!("ZQUANTIZ value not recognized");
-                    None
-                }
-            }
-        } else {
+        let z_quantiz = values.get_parsed("ZQUANTIZ").unwrap_or_else(|err| {
+            warn!("ZQUANTIZ value not recognized: {}", err);
             None
-        };
+        });
 
         // ZDITHER0 (optional keyword) The value field of this keyword shall contain an integer that
         // gives the seed value for the random dithering pattern that was used when quantizing the
@@ -535,8 +515,8 @@ impl Xtension for BinTable {
         };
 
         // update the value of theap if found
-        let theap = if let Ok(value) = values.get_parsed::<i64>("THEAP") {
-            value as usize
+        let theap = if let Ok(value) = values.get_parsed::<usize>("THEAP") {
+            value
         } else {
             (naxis1 as usize) * (naxis2 as usize)
         };

--- a/src/hdu/header/extension/image.rs
+++ b/src/hdu/header/extension/image.rs
@@ -1,6 +1,5 @@
 use async_trait::async_trait;
 use serde::Serialize;
-use std::collections::HashMap;
 
 use crate::card::Value;
 use crate::error::Error;
@@ -8,6 +7,7 @@ use crate::hdu::header::check_for_bitpix;
 use crate::hdu::header::check_for_naxis;
 use crate::hdu::header::Bitpix;
 
+use crate::hdu::header::ValueMap;
 use crate::hdu::header::Xtension;
 
 #[derive(Debug, PartialEq, Serialize, Clone)]
@@ -51,7 +51,7 @@ impl Xtension for Image {
         num_bits >> 3
     }
 
-    fn parse(values: &HashMap<String, Value>) -> Result<Self, Error> {
+    fn parse(values: &ValueMap) -> Result<Self, Error> {
         // BITPIX
         let bitpix = check_for_bitpix(values)?;
         // NAXIS

--- a/src/hdu/header/extension/image.rs
+++ b/src/hdu/header/extension/image.rs
@@ -1,7 +1,6 @@
 use async_trait::async_trait;
 use serde::Serialize;
 
-use crate::card::Value;
 use crate::error::Error;
 use crate::hdu::header::check_for_bitpix;
 use crate::hdu::header::check_for_naxis;
@@ -59,12 +58,9 @@ impl Xtension for Image {
         // The size of each NAXIS
         let naxisn = (1..=naxis)
             .map(|naxis_i| {
-                let naxis = format!("NAXIS{naxis_i}");
-                if let Some(Value::Integer { value, .. }) = values.get(&naxis) {
-                    Ok(*value as u64)
-                } else {
-                    Err(Error::FailFindingKeyword(naxis))
-                }
+                values
+                    .get_parsed(&format!("NAXIS{naxis_i}"))
+                    .map(|value: i64| value as _)
             })
             .collect::<Result<Vec<_>, _>>()?;
 

--- a/src/hdu/header/extension/image.rs
+++ b/src/hdu/header/extension/image.rs
@@ -57,12 +57,8 @@ impl Xtension for Image {
         let naxis = check_for_naxis(values)?;
         // The size of each NAXIS
         let naxisn = (1..=naxis)
-            .map(|naxis_i| {
-                values
-                    .get_parsed(&format!("NAXIS{naxis_i}"))
-                    .map(|value: i64| value as _)
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+            .map(|naxis_i| values.get_parsed(&format!("NAXIS{naxis_i}")))
+            .collect::<Result<_, _>>()?;
 
         Ok(Image {
             bitpix,

--- a/src/hdu/header/extension/image.rs
+++ b/src/hdu/header/extension/image.rs
@@ -2,8 +2,6 @@ use async_trait::async_trait;
 use serde::Serialize;
 
 use crate::error::Error;
-use crate::hdu::header::check_for_bitpix;
-use crate::hdu::header::check_for_naxis;
 use crate::hdu::header::Bitpix;
 
 use crate::hdu::header::ValueMap;
@@ -52,9 +50,9 @@ impl Xtension for Image {
 
     fn parse(values: &ValueMap) -> Result<Self, Error> {
         // BITPIX
-        let bitpix = check_for_bitpix(values)?;
+        let bitpix = values.check_for_bitpix()?;
         // NAXIS
-        let naxis = check_for_naxis(values)?;
+        let naxis = values.check_for_naxis()?;
         // The size of each NAXIS
         let naxisn = (1..=naxis)
             .map(|naxis_i| values.get_parsed(&format!("NAXIS{naxis_i}")))

--- a/src/hdu/header/extension/image.rs
+++ b/src/hdu/header/extension/image.rs
@@ -52,15 +52,15 @@ impl Xtension for Image {
         // BITPIX
         let bitpix = values.check_for_bitpix()?;
         // NAXIS
-        let naxis = values.check_for_naxis()?;
+        let naxis = values.check_for_naxis()? as usize;
         // The size of each NAXIS
         let naxisn = (1..=naxis)
-            .map(|naxis_i| values.get_parsed(&format!("NAXIS{naxis_i}")))
+            .map(|naxis_i| values.check_for_naxisi(naxis_i))
             .collect::<Result<_, _>>()?;
 
         Ok(Image {
             bitpix,
-            naxis: naxis as usize,
+            naxis,
             naxisn,
         })
     }

--- a/src/hdu/header/extension/mod.rs
+++ b/src/hdu/header/extension/mod.rs
@@ -7,10 +7,8 @@ use std::convert::TryFrom;
 use async_trait::async_trait;
 use serde::Serialize;
 
-use crate::card::Value;
+use super::ValueMap;
 use crate::error::Error;
-
-use std::collections::HashMap;
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug, Serialize)]
 pub enum XtensionType {
@@ -49,7 +47,7 @@ pub trait Xtension {
 
     // Parse the Xtension keywords
     // During the parsing, some checks will be made
-    fn parse(values: &HashMap<String, Value>) -> Result<Self, Error>
+    fn parse(values: &ValueMap) -> Result<Self, Error>
     where
         Self: Sized;
 }

--- a/src/hdu/header/extension/mod.rs
+++ b/src/hdu/header/extension/mod.rs
@@ -2,7 +2,7 @@ pub mod asciitable;
 pub mod bintable;
 pub mod image;
 
-use std::convert::TryFrom;
+use std::str::FromStr;
 
 use async_trait::async_trait;
 use serde::Serialize;
@@ -17,20 +17,26 @@ pub enum XtensionType {
     AsciiTable,
 }
 
-impl From<XtensionType> for String {
-    fn from(val: XtensionType) -> Self {
-        match val {
-            XtensionType::Image => "IMAGE".to_owned(),
-            XtensionType::BinTable => "BINTABLE".to_owned(),
-            XtensionType::AsciiTable => "TABLE".to_owned(),
+impl XtensionType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            XtensionType::Image => "IMAGE",
+            XtensionType::BinTable => "BINTABLE",
+            XtensionType::AsciiTable => "TABLE",
         }
     }
 }
 
-impl TryFrom<&str> for XtensionType {
-    type Error = Error;
+impl std::fmt::Display for XtensionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
 
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+impl FromStr for XtensionType {
+    type Err = Error;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
         match value {
             "IMAGE" | "IUEIMAGE" => Ok(XtensionType::Image),
             "TABLE" => Ok(XtensionType::AsciiTable),

--- a/src/hdu/header/mod.rs
+++ b/src/hdu/header/mod.rs
@@ -62,60 +62,28 @@ pub fn check_card_keyword(card: &[u8; 80], keyword: &[u8; 8]) -> Result<card::Va
 
 /* Mandatory keywords parsing */
 fn check_for_bitpix(values: &ValueMap) -> Result<Bitpix, Error> {
-    if let Some(Value::Integer { value, .. }) = values.get("BITPIX") {
-        match value {
-            8 => Ok(Bitpix::U8),
-            16 => Ok(Bitpix::I16),
-            32 => Ok(Bitpix::I32),
-            64 => Ok(Bitpix::I64),
-            -32 => Ok(Bitpix::F32),
-            -64 => Ok(Bitpix::F64),
-            _ => Err(Error::BitpixBadValue),
-        }
-    } else {
-        Err(Error::FailFindingKeyword("BITPIX".to_owned()))
-    }
+    values.get_parsed("BITPIX")
 }
 
 fn check_for_naxis(values: &ValueMap) -> Result<u64, Error> {
-    if let Some(Value::Integer { value, .. }) = values.get("NAXIS") {
-        Ok(*value as u64)
-    } else {
-        Err(Error::FailFindingKeyword("NAXIS".to_owned()))
-    }
+    values.get_parsed("NAXIS").map(|value: i64| value as _)
 }
 
 fn check_for_naxisi(values: &ValueMap, i: usize) -> Result<u64, Error> {
     let naxisi = format!("NAXIS{i}");
-    if let Some(Value::Integer { value, .. }) = values.get(&naxisi) {
-        Ok(*value as u64)
-    } else {
-        Err(Error::FailFindingKeyword(naxisi))
-    }
+    values.get_parsed(&naxisi).map(|value: i64| value as _)
 }
 
 fn check_for_gcount(values: &ValueMap) -> Result<u64, Error> {
-    if let Some(Value::Integer { value, .. }) = values.get("GCOUNT") {
-        Ok(*value as u64)
-    } else {
-        Err(Error::FailFindingKeyword("GCOUNT".to_owned()))
-    }
+    values.get_parsed("GCOUNT").map(|value: i64| value as _)
 }
 
 fn check_for_pcount(values: &ValueMap) -> Result<u64, Error> {
-    if let Some(Value::Integer { value, .. }) = values.get("PCOUNT") {
-        Ok(*value as u64)
-    } else {
-        Err(Error::FailFindingKeyword("PCOUNT".to_owned()))
-    }
+    values.get_parsed("PCOUNT").map(|value: i64| value as _)
 }
 
 fn check_for_tfields(values: &ValueMap) -> Result<usize, Error> {
-    if let Some(Value::Integer { value, .. }) = values.get("TFIELDS") {
-        Ok(*value as usize)
-    } else {
-        Err(Error::FailFindingKeyword("TFIELDS".to_owned()))
-    }
+    values.get_parsed("TFIELDS").map(|value: i64| value as _)
 }
 
 #[derive(Debug, PartialEq, Serialize, Clone, Copy)]
@@ -126,6 +94,20 @@ pub enum Bitpix {
     I64 = 64,
     F32 = -32,
     F64 = -64,
+}
+
+impl CardValue for Bitpix {
+    fn parse(value: &Value) -> Result<Self, Error> {
+        Ok(match i64::parse(value)? {
+            8 => Bitpix::U8,
+            16 => Bitpix::I16,
+            32 => Bitpix::I32,
+            64 => Bitpix::I64,
+            -32 => Bitpix::F32,
+            -64 => Bitpix::F64,
+            _ => return Err(Error::BitpixBadValue),
+        })
+    }
 }
 
 impl Bitpix {

--- a/src/hdu/header/mod.rs
+++ b/src/hdu/header/mod.rs
@@ -62,31 +62,6 @@ pub fn check_card_keyword(card: &[u8; 80], keyword: &[u8; 8]) -> Result<card::Va
     }
 }
 
-/* Mandatory keywords parsing */
-fn check_for_bitpix(values: &ValueMap) -> Result<Bitpix, Error> {
-    values.get_parsed("BITPIX")
-}
-
-fn check_for_naxis(values: &ValueMap) -> Result<u64, Error> {
-    values.get_parsed("NAXIS")
-}
-
-fn check_for_naxisi(values: &ValueMap, i: usize) -> Result<u64, Error> {
-    values.get_parsed(&format!("NAXIS{i}"))
-}
-
-fn check_for_gcount(values: &ValueMap) -> Result<u64, Error> {
-    values.get_parsed("GCOUNT")
-}
-
-fn check_for_pcount(values: &ValueMap) -> Result<u64, Error> {
-    values.get_parsed("PCOUNT")
-}
-
-fn check_for_tfields(values: &ValueMap) -> Result<usize, Error> {
-    values.get_parsed("TFIELDS")
-}
-
 #[derive(Debug, PartialEq, Serialize_repr, Deserialize_repr, Clone, Copy)]
 #[repr(i8)]
 pub enum Bitpix {
@@ -154,6 +129,32 @@ impl ValueMap {
     /// in the FITS header.
     pub fn keywords(&self) -> Keys<String, Value> {
         self.values.keys()
+    }
+
+    /* Mandatory keywords parsing */
+
+    fn check_for_bitpix(&self) -> Result<Bitpix, Error> {
+        self.get_parsed("BITPIX")
+    }
+
+    fn check_for_naxis(&self) -> Result<u64, Error> {
+        self.get_parsed("NAXIS")
+    }
+
+    fn check_for_naxisi(&self, i: usize) -> Result<u64, Error> {
+        self.get_parsed(&format!("NAXIS{i}"))
+    }
+
+    fn check_for_gcount(&self) -> Result<u64, Error> {
+        self.get_parsed("GCOUNT")
+    }
+
+    fn check_for_pcount(&self) -> Result<u64, Error> {
+        self.get_parsed("PCOUNT")
+    }
+
+    fn check_for_tfields(&self) -> Result<usize, Error> {
+        self.get_parsed("TFIELDS")
     }
 }
 

--- a/src/hdu/header/mod.rs
+++ b/src/hdu/header/mod.rs
@@ -3,6 +3,7 @@
 //! A header consists of a list a of [cards](Card) where each card is a line of
 //! 80 ASCII characters.
 use futures::{AsyncRead, AsyncReadExt};
+use indexmap::map::{IndexMap, Keys};
 use log::warn;
 use serde::Serialize;
 
@@ -10,10 +11,9 @@ pub mod extension;
 
 pub use extension::Xtension;
 
-use std::collections::hash_map::Keys;
-use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::io::Read;
+use std::ops::Deref;
 
 use crate::{
     card::{self, *},
@@ -61,7 +61,7 @@ pub fn check_card_keyword(card: &[u8; 80], keyword: &[u8; 8]) -> Result<card::Va
 }
 
 /* Mandatory keywords parsing */
-fn check_for_bitpix(values: &HashMap<String, Value>) -> Result<Bitpix, Error> {
+fn check_for_bitpix(values: &ValueMap) -> Result<Bitpix, Error> {
     if let Some(Value::Integer { value, .. }) = values.get("BITPIX") {
         match value {
             8 => Ok(Bitpix::U8),
@@ -77,7 +77,7 @@ fn check_for_bitpix(values: &HashMap<String, Value>) -> Result<Bitpix, Error> {
     }
 }
 
-fn check_for_naxis(values: &HashMap<String, Value>) -> Result<u64, Error> {
+fn check_for_naxis(values: &ValueMap) -> Result<u64, Error> {
     if let Some(Value::Integer { value, .. }) = values.get("NAXIS") {
         Ok(*value as u64)
     } else {
@@ -85,7 +85,7 @@ fn check_for_naxis(values: &HashMap<String, Value>) -> Result<u64, Error> {
     }
 }
 
-fn check_for_naxisi(values: &HashMap<String, Value>, i: usize) -> Result<u64, Error> {
+fn check_for_naxisi(values: &ValueMap, i: usize) -> Result<u64, Error> {
     let naxisi = format!("NAXIS{i}");
     if let Some(Value::Integer { value, .. }) = values.get(&naxisi) {
         Ok(*value as u64)
@@ -94,7 +94,7 @@ fn check_for_naxisi(values: &HashMap<String, Value>, i: usize) -> Result<u64, Er
     }
 }
 
-fn check_for_gcount(values: &HashMap<String, Value>) -> Result<u64, Error> {
+fn check_for_gcount(values: &ValueMap) -> Result<u64, Error> {
     if let Some(Value::Integer { value, .. }) = values.get("GCOUNT") {
         Ok(*value as u64)
     } else {
@@ -102,7 +102,7 @@ fn check_for_gcount(values: &HashMap<String, Value>) -> Result<u64, Error> {
     }
 }
 
-fn check_for_pcount(values: &HashMap<String, Value>) -> Result<u64, Error> {
+fn check_for_pcount(values: &ValueMap) -> Result<u64, Error> {
     if let Some(Value::Integer { value, .. }) = values.get("PCOUNT") {
         Ok(*value as u64)
     } else {
@@ -110,7 +110,7 @@ fn check_for_pcount(values: &HashMap<String, Value>) -> Result<u64, Error> {
     }
 }
 
-fn check_for_tfields(values: &HashMap<String, Value>) -> Result<usize, Error> {
+fn check_for_tfields(values: &ValueMap) -> Result<usize, Error> {
     if let Some(Value::Integer { value, .. }) = values.get("TFIELDS") {
         Ok(*value as usize)
     } else {
@@ -134,6 +134,78 @@ impl Bitpix {
     }
 }
 
+#[derive(Debug, PartialEq, Serialize, Clone)]
+#[serde(transparent)]
+pub struct ValueMap {
+    values: IndexMap<String, Value>,
+}
+
+impl ValueMap {
+    /// Get the value of a card, returns `None` if the card is not
+    /// found or is not a value card.
+    pub fn get(&self, key: &str) -> Option<&Value> {
+        self.values.get(key)
+    }
+
+    /// Get the value a specific card and try to parse the value. Returns an
+    /// error if the asking type does not match the true inner type of the value.
+    ///
+    /// # Params
+    /// * `key` - The key of a card
+    pub fn try_get_parsed<T>(&self, key: &str) -> Result<Option<T>, Error>
+    where
+        T: CardValue,
+    {
+        self.get(key)
+            .map(|value| {
+                <T as CardValue>::parse(value).map_err(|_| {
+                    Error::FailTypeCardParsing(
+                        key.to_string(),
+                        std::any::type_name::<T>().to_string(),
+                    )
+                })
+            })
+            .transpose()
+    }
+
+    /// Get the value a specific card and try to parse the value. Returns an
+    /// error if the value is not in the map or the asking type does not match
+    /// the true inner type of the value.
+    ///
+    /// # Params
+    /// * `key` - The key of a card
+    pub fn get_parsed<T>(&self, key: &str) -> Result<T, Error>
+    where
+        T: CardValue,
+    {
+        self.try_get_parsed(key)?
+            .ok_or_else(|| Error::FailFindingKeyword(key.to_string()))
+    }
+
+    /// Return an iterator over all key-[value](Card::Value) pairs in the FITS
+    /// header.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &Value)> {
+        self.values.iter().map(|(k, v)| (k.as_str(), v))
+    }
+
+    /// Get the keyword corresponding to a specific value, returns `None` if
+    /// no card are found with that value. If multiple cards do have the same value
+    /// then the first found card's keyword will be returned.
+    ///
+    /// # Params
+    /// * `value` - The value of a card
+    pub fn get_keyword(&self, val: &Value) -> Option<&str> {
+        self.iter()
+            .find_map(|(name, value)| (value == val).then_some(name))
+    }
+
+    /// Return an iterator over all keywords representing a FITS [Card::Value]
+    /// in the FITS header.
+    pub fn keywords(&self) -> Keys<String, Value> {
+        self.values.keys()
+    }
+}
+
 /// The header part of an [crate::hdu::HDU].
 #[derive(Debug, PartialEq, Serialize, Clone)]
 pub struct Header<X> {
@@ -146,9 +218,17 @@ pub struct Header<X> {
     ///   buffer used on the [Card].
     /// * If contrary to the FITS standard, a keyword appears more than once in
     ///   the header, the value of the last [Card::Value] is returned.
-    values: HashMap<String, Value>,
+    values: ValueMap,
     /// Mandatory keywords for fits ext parsing.
     xtension: X,
+}
+
+impl<X> Deref for Header<X> {
+    type Target = ValueMap;
+
+    fn deref(&self) -> &Self::Target {
+        &self.values
+    }
 }
 
 impl<X> Header<X>
@@ -172,54 +252,6 @@ where
         &self.xtension
     }
 
-    /// Get the value of a card, returns `None` if the card is not
-    /// found or is not a value card.
-    pub fn get(&self, key: &str) -> Option<&Value> {
-        self.values.get(key)
-    }
-
-    /// Get the value a specific card and try to parse the value. Returns an
-    /// error if the asking type does not match the true inner type of the value.
-    ///
-    /// # Params
-    /// * `key` - The key of a card
-    pub fn get_parsed<T>(&self, key: &str) -> Option<Result<T, Error>>
-    where
-        T: CardValue,
-    {
-        self.get(key).map(|value| {
-            <T as CardValue>::parse(value.clone()).map_err(|_| {
-                Error::FailTypeCardParsing(key.to_string(), std::any::type_name::<T>().to_string())
-            })
-        })
-    }
-
-    /// Get the keyword corresponding to a specific value, returns `None` if
-    /// no card are found with that value. If multiple cards do have the same value
-    /// then the first found card's keyword will be returned.
-    ///
-    /// # Params
-    /// * `value` - The value of a card
-    pub fn get_keyword(&self, val: &Value) -> Option<&str> {
-        self.cards().find_map(|card| {
-            if let Card::Value { name, value } = card {
-                if value == val {
-                    Some(name.as_str())
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        })
-    }
-
-    /// Return an iterator over all keywords representing a FITS [Card::Value]
-    /// in the FITS header.
-    pub fn keywords(&self) -> Keys<String, Value> {
-        self.values.keys()
-    }
-
     /// Return an iterator over all [cards](Card) in the FITS header.
     pub fn cards(&self) -> impl Iterator<Item = &Card> + '_ {
         self.cards.iter()
@@ -239,8 +271,8 @@ where
     }
 }
 
-fn process_cards(cards: &[Card]) -> Result<HashMap<String, Value>, Error> {
-    let mut values = HashMap::new();
+fn process_cards(cards: &[Card]) -> Result<ValueMap, Error> {
+    let mut values = IndexMap::new();
     let mut kw: Option<String> = None;
 
     for (i, card) in cards.iter().enumerate() {
@@ -295,7 +327,7 @@ fn process_cards(cards: &[Card]) -> Result<HashMap<String, Value>, Error> {
             }
             Card::End => {
                 if i + 1 == cards.len() {
-                    return Ok(values);
+                    return Ok(ValueMap { values });
                 } else {
                     unreachable!("cards trailing after the END card")
                 }

--- a/src/hdu/header/mod.rs
+++ b/src/hdu/header/mod.rs
@@ -296,7 +296,7 @@ fn process_cards(cards: &[Card]) -> Result<ValueMap, Error> {
                 values.insert(
                     "XTENSION".to_owned(),
                     Value::String {
-                        value: (*x).into(),
+                        value: x.to_string(),
                         comment: None,
                     },
                 );

--- a/src/wcs.rs
+++ b/src/wcs.rs
@@ -1,14 +1,14 @@
-use crate::card::CardValue;
 use crate::error::Error;
 use crate::hdu::header::extension::image::Image;
 use crate::hdu::header::Header;
 use std::convert::TryFrom;
-use std::str::FromStr;
 
 pub type ImgXY = wcs::ImgXY;
 pub type LonLat = wcs::LonLat;
 
 use crate::fits::HDU;
+use serde::de::IntoDeserializer;
+use serde::Deserialize;
 use std::convert::TryInto;
 pub use wcs::{WCSParams, WCS};
 
@@ -19,223 +19,11 @@ impl HDU<Image> {
     }
 }
 
-fn parse_optional_card_with_type<T: CardValue + FromStr>(
-    header: &Header<Image>,
-    key: &'static str,
-) -> Result<Option<T>, Error> {
-    let Some(value) = header.get(key) else {
-        // card not found but it is ok as it is not mandatory
-        return Ok(None);
-    };
-    if let Ok(v) = T::parse(value) {
-        return Ok(Some(v));
-    }
-    // if the value is a string, we try to fallback to parsing that string
-    // TODO: is this really necessary?
-    match value.check_for_string()?.trim().parse() {
-        Ok(v) => Ok(Some(v)),
-        Err(_) => Err(Error::ValueBadParsing),
-    }
-}
-
-fn parse_mandatory_card_with_type<T: CardValue>(
-    header: &Header<Image>,
-    key: &'static str,
-) -> Result<T, Error> {
-    header.get_parsed::<T>(key)
-}
-
 impl<'a> TryFrom<&'a Header<Image>> for WCS {
     type Error = Error;
 
     fn try_from(h: &'a Header<Image>) -> Result<Self, Self::Error> {
-        let params = WCSParams {
-            ctype1: parse_mandatory_card_with_type::<String>(h, "CTYPE1")?,
-            naxis: parse_mandatory_card_with_type::<i64>(h, "NAXIS")?,
-
-            naxis1: parse_optional_card_with_type::<i64>(h, "NAXIS1")?,
-            naxis2: parse_optional_card_with_type::<i64>(h, "NAXIS2")?,
-            ctype2: parse_optional_card_with_type::<String>(h, "CTYPE2")?,
-            ctype3: parse_optional_card_with_type::<String>(h, "CTYPE3")?,
-            a_order: parse_optional_card_with_type::<i64>(h, "A_ORDER")?,
-            b_order: parse_optional_card_with_type::<i64>(h, "B_ORDER")?,
-            ap_order: parse_optional_card_with_type::<i64>(h, "AP_ORDER")?,
-            bp_order: parse_optional_card_with_type::<i64>(h, "BP_ORDER")?,
-            crpix1: parse_optional_card_with_type::<f64>(h, "CRPIX1")?,
-            crpix2: parse_optional_card_with_type::<f64>(h, "CRPIX2")?,
-            crpix3: parse_optional_card_with_type::<f64>(h, "CRPIX3")?,
-            crval1: parse_optional_card_with_type::<f64>(h, "CRVAL1")?,
-            crval2: parse_optional_card_with_type::<f64>(h, "CRVAL2")?,
-            crval3: parse_optional_card_with_type::<f64>(h, "CRVAL3")?,
-            crota1: parse_optional_card_with_type::<f64>(h, "CROTA1")?,
-            crota2: parse_optional_card_with_type::<f64>(h, "CROTA2")?,
-            crota3: parse_optional_card_with_type::<f64>(h, "CROTA3")?,
-            cdelt1: parse_optional_card_with_type::<f64>(h, "CDELT1")?,
-            cdelt2: parse_optional_card_with_type::<f64>(h, "CDELT2")?,
-            cdelt3: parse_optional_card_with_type::<f64>(h, "CDELT3")?,
-            naxis3: parse_optional_card_with_type::<i64>(h, "NAXIS3")?,
-            naxis4: parse_optional_card_with_type::<i64>(h, "NAXIS4")?,
-            lonpole: parse_optional_card_with_type::<f64>(h, "LONPOLE")?,
-            latpole: parse_optional_card_with_type::<f64>(h, "LATPOLE")?,
-            equinox: parse_optional_card_with_type::<f64>(h, "EQUINOX")?,
-            epoch: parse_optional_card_with_type::<f64>(h, "EPOCH")?,
-            radesys: parse_optional_card_with_type::<String>(h, "RADESYS")?,
-            pv1_0: parse_optional_card_with_type::<f64>(h, "PV1_0")?,
-            pv1_1: parse_optional_card_with_type::<f64>(h, "PV1_1")?,
-            pv1_2: parse_optional_card_with_type::<f64>(h, "PV1_2")?,
-            pv2_0: parse_optional_card_with_type::<f64>(h, "PV2_0")?,
-            pv2_1: parse_optional_card_with_type::<f64>(h, "PV2_1")?,
-            pv2_2: parse_optional_card_with_type::<f64>(h, "PV2_2")?,
-            pv2_3: parse_optional_card_with_type::<f64>(h, "PV2_3")?,
-            pv2_4: parse_optional_card_with_type::<f64>(h, "PV2_4")?,
-            pv2_5: parse_optional_card_with_type::<f64>(h, "PV2_5")?,
-            pv2_6: parse_optional_card_with_type::<f64>(h, "PV2_6")?,
-            pv2_7: parse_optional_card_with_type::<f64>(h, "PV2_7")?,
-            pv2_8: parse_optional_card_with_type::<f64>(h, "PV2_8")?,
-            pv2_9: parse_optional_card_with_type::<f64>(h, "PV2_9")?,
-            pv2_10: parse_optional_card_with_type::<f64>(h, "PV2_10")?,
-            pv2_11: parse_optional_card_with_type::<f64>(h, "PV2_11")?,
-            pv2_12: parse_optional_card_with_type::<f64>(h, "PV2_12")?,
-            pv2_13: parse_optional_card_with_type::<f64>(h, "PV2_13")?,
-            pv2_14: parse_optional_card_with_type::<f64>(h, "PV2_14")?,
-            pv2_15: parse_optional_card_with_type::<f64>(h, "PV2_15")?,
-            pv2_16: parse_optional_card_with_type::<f64>(h, "PV2_16")?,
-            pv2_17: parse_optional_card_with_type::<f64>(h, "PV2_17")?,
-            pv2_18: parse_optional_card_with_type::<f64>(h, "PV2_18")?,
-            pv2_19: parse_optional_card_with_type::<f64>(h, "PV2_19")?,
-            pv2_20: parse_optional_card_with_type::<f64>(h, "PV2_20")?,
-            cd1_1: parse_optional_card_with_type::<f64>(h, "CD1_1")?,
-            cd1_2: parse_optional_card_with_type::<f64>(h, "CD1_2")?,
-            cd1_3: parse_optional_card_with_type::<f64>(h, "CD1_3")?,
-            cd2_1: parse_optional_card_with_type::<f64>(h, "CD2_1")?,
-            cd2_2: parse_optional_card_with_type::<f64>(h, "CD2_2")?,
-            cd2_3: parse_optional_card_with_type::<f64>(h, "CD2_3")?,
-            cd3_1: parse_optional_card_with_type::<f64>(h, "CD3_1")?,
-            cd3_2: parse_optional_card_with_type::<f64>(h, "CD3_2")?,
-            cd3_3: parse_optional_card_with_type::<f64>(h, "CD3_3")?,
-            pc1_1: parse_optional_card_with_type::<f64>(h, "PC1_1")?,
-            pc1_2: parse_optional_card_with_type::<f64>(h, "PC1_2")?,
-            pc1_3: parse_optional_card_with_type::<f64>(h, "PC1_3")?,
-            pc2_1: parse_optional_card_with_type::<f64>(h, "PC2_1")?,
-            pc2_2: parse_optional_card_with_type::<f64>(h, "PC2_2")?,
-            pc2_3: parse_optional_card_with_type::<f64>(h, "PC2_3")?,
-            pc3_1: parse_optional_card_with_type::<f64>(h, "PC3_1")?,
-            pc3_2: parse_optional_card_with_type::<f64>(h, "PC3_2")?,
-            pc3_3: parse_optional_card_with_type::<f64>(h, "PC3_3")?,
-            a_0_0: parse_optional_card_with_type::<f64>(h, "A_0_0")?,
-            a_1_0: parse_optional_card_with_type::<f64>(h, "A_1_0")?,
-            a_2_0: parse_optional_card_with_type::<f64>(h, "A_2_0")?,
-            a_3_0: parse_optional_card_with_type::<f64>(h, "A_3_0")?,
-            a_4_0: parse_optional_card_with_type::<f64>(h, "A_4_0")?,
-            a_5_0: parse_optional_card_with_type::<f64>(h, "A_5_0")?,
-            a_6_0: parse_optional_card_with_type::<f64>(h, "A_6_0")?,
-            a_0_1: parse_optional_card_with_type::<f64>(h, "A_0_1")?,
-            a_1_1: parse_optional_card_with_type::<f64>(h, "A_1_1")?,
-            a_2_1: parse_optional_card_with_type::<f64>(h, "A_2_1")?,
-            a_3_1: parse_optional_card_with_type::<f64>(h, "A_3_1")?,
-            a_4_1: parse_optional_card_with_type::<f64>(h, "A_4_1")?,
-            a_5_1: parse_optional_card_with_type::<f64>(h, "A_5_1")?,
-            a_0_2: parse_optional_card_with_type::<f64>(h, "A_0_2")?,
-            a_1_2: parse_optional_card_with_type::<f64>(h, "A_1_2")?,
-            a_2_2: parse_optional_card_with_type::<f64>(h, "A_2_2")?,
-            a_3_2: parse_optional_card_with_type::<f64>(h, "A_3_2")?,
-            a_4_2: parse_optional_card_with_type::<f64>(h, "A_4_2")?,
-            a_0_3: parse_optional_card_with_type::<f64>(h, "A_0_3")?,
-            a_1_3: parse_optional_card_with_type::<f64>(h, "A_1_3")?,
-            a_2_3: parse_optional_card_with_type::<f64>(h, "A_2_3")?,
-            a_3_3: parse_optional_card_with_type::<f64>(h, "A_3_3")?,
-            a_0_4: parse_optional_card_with_type::<f64>(h, "A_0_4")?,
-            a_1_4: parse_optional_card_with_type::<f64>(h, "A_1_4")?,
-            a_2_4: parse_optional_card_with_type::<f64>(h, "A_2_4")?,
-            a_0_5: parse_optional_card_with_type::<f64>(h, "A_0_5")?,
-            a_1_5: parse_optional_card_with_type::<f64>(h, "A_1_5")?,
-            a_0_6: parse_optional_card_with_type::<f64>(h, "A_0_6")?,
-            ap_0_0: parse_optional_card_with_type::<f64>(h, "AP_0_0")?,
-            ap_1_0: parse_optional_card_with_type::<f64>(h, "AP_1_0")?,
-            ap_2_0: parse_optional_card_with_type::<f64>(h, "AP_2_0")?,
-            ap_3_0: parse_optional_card_with_type::<f64>(h, "AP_3_0")?,
-            ap_4_0: parse_optional_card_with_type::<f64>(h, "AP_4_0")?,
-            ap_5_0: parse_optional_card_with_type::<f64>(h, "AP_5_0")?,
-            ap_6_0: parse_optional_card_with_type::<f64>(h, "AP_6_0")?,
-            ap_0_1: parse_optional_card_with_type::<f64>(h, "AP_0_1")?,
-            ap_1_1: parse_optional_card_with_type::<f64>(h, "AP_1_1")?,
-            ap_2_1: parse_optional_card_with_type::<f64>(h, "AP_2_1")?,
-            ap_3_1: parse_optional_card_with_type::<f64>(h, "AP_3_1")?,
-            ap_4_1: parse_optional_card_with_type::<f64>(h, "AP_4_1")?,
-            ap_5_1: parse_optional_card_with_type::<f64>(h, "AP_5_1")?,
-            ap_0_2: parse_optional_card_with_type::<f64>(h, "AP_0_2")?,
-            ap_1_2: parse_optional_card_with_type::<f64>(h, "AP_1_2")?,
-            ap_2_2: parse_optional_card_with_type::<f64>(h, "AP_2_2")?,
-            ap_3_2: parse_optional_card_with_type::<f64>(h, "AP_3_2")?,
-            ap_4_2: parse_optional_card_with_type::<f64>(h, "AP_4_2")?,
-            ap_0_3: parse_optional_card_with_type::<f64>(h, "AP_0_3")?,
-            ap_1_3: parse_optional_card_with_type::<f64>(h, "AP_1_3")?,
-            ap_2_3: parse_optional_card_with_type::<f64>(h, "AP_2_3")?,
-            ap_3_3: parse_optional_card_with_type::<f64>(h, "AP_3_3")?,
-            ap_0_4: parse_optional_card_with_type::<f64>(h, "AP_0_4")?,
-            ap_1_4: parse_optional_card_with_type::<f64>(h, "AP_1_4")?,
-            ap_2_4: parse_optional_card_with_type::<f64>(h, "AP_2_4")?,
-            ap_0_5: parse_optional_card_with_type::<f64>(h, "AP_0_5")?,
-            ap_1_5: parse_optional_card_with_type::<f64>(h, "AP_1_5")?,
-            ap_0_6: parse_optional_card_with_type::<f64>(h, "AP_0_6")?,
-            b_0_0: parse_optional_card_with_type::<f64>(h, "B_0_0")?,
-            b_1_0: parse_optional_card_with_type::<f64>(h, "B_1_0")?,
-            b_2_0: parse_optional_card_with_type::<f64>(h, "B_2_0")?,
-            b_3_0: parse_optional_card_with_type::<f64>(h, "B_3_0")?,
-            b_4_0: parse_optional_card_with_type::<f64>(h, "B_4_0")?,
-            b_5_0: parse_optional_card_with_type::<f64>(h, "B_5_0")?,
-            b_6_0: parse_optional_card_with_type::<f64>(h, "B_6_0")?,
-            b_0_1: parse_optional_card_with_type::<f64>(h, "B_0_1")?,
-            b_1_1: parse_optional_card_with_type::<f64>(h, "B_1_1")?,
-            b_2_1: parse_optional_card_with_type::<f64>(h, "B_2_1")?,
-            b_3_1: parse_optional_card_with_type::<f64>(h, "B_3_1")?,
-            b_4_1: parse_optional_card_with_type::<f64>(h, "B_4_1")?,
-            b_5_1: parse_optional_card_with_type::<f64>(h, "B_5_1")?,
-            b_0_2: parse_optional_card_with_type::<f64>(h, "B_0_2")?,
-            b_1_2: parse_optional_card_with_type::<f64>(h, "B_1_2")?,
-            b_2_2: parse_optional_card_with_type::<f64>(h, "B_2_2")?,
-            b_3_2: parse_optional_card_with_type::<f64>(h, "B_3_2")?,
-            b_4_2: parse_optional_card_with_type::<f64>(h, "B_4_2")?,
-            b_0_3: parse_optional_card_with_type::<f64>(h, "B_0_3")?,
-            b_1_3: parse_optional_card_with_type::<f64>(h, "B_1_3")?,
-            b_2_3: parse_optional_card_with_type::<f64>(h, "B_2_3")?,
-            b_3_3: parse_optional_card_with_type::<f64>(h, "B_3_3")?,
-            b_0_4: parse_optional_card_with_type::<f64>(h, "B_0_4")?,
-            b_1_4: parse_optional_card_with_type::<f64>(h, "B_1_4")?,
-            b_2_4: parse_optional_card_with_type::<f64>(h, "B_2_4")?,
-            b_0_5: parse_optional_card_with_type::<f64>(h, "B_0_5")?,
-            b_1_5: parse_optional_card_with_type::<f64>(h, "B_1_5")?,
-            b_0_6: parse_optional_card_with_type::<f64>(h, "B_0_6")?,
-            bp_0_0: parse_optional_card_with_type::<f64>(h, "BP_0_0")?,
-            bp_1_0: parse_optional_card_with_type::<f64>(h, "BP_1_0")?,
-            bp_2_0: parse_optional_card_with_type::<f64>(h, "BP_2_0")?,
-            bp_3_0: parse_optional_card_with_type::<f64>(h, "BP_3_0")?,
-            bp_4_0: parse_optional_card_with_type::<f64>(h, "BP_4_0")?,
-            bp_5_0: parse_optional_card_with_type::<f64>(h, "BP_5_0")?,
-            bp_6_0: parse_optional_card_with_type::<f64>(h, "BP_6_0")?,
-            bp_0_1: parse_optional_card_with_type::<f64>(h, "BP_0_1")?,
-            bp_1_1: parse_optional_card_with_type::<f64>(h, "BP_1_1")?,
-            bp_2_1: parse_optional_card_with_type::<f64>(h, "BP_2_1")?,
-            bp_3_1: parse_optional_card_with_type::<f64>(h, "BP_3_1")?,
-            bp_4_1: parse_optional_card_with_type::<f64>(h, "BP_4_1")?,
-            bp_5_1: parse_optional_card_with_type::<f64>(h, "BP_5_1")?,
-            bp_0_2: parse_optional_card_with_type::<f64>(h, "BP_0_2")?,
-            bp_1_2: parse_optional_card_with_type::<f64>(h, "BP_1_2")?,
-            bp_2_2: parse_optional_card_with_type::<f64>(h, "BP_2_2")?,
-            bp_3_2: parse_optional_card_with_type::<f64>(h, "BP_3_2")?,
-            bp_4_2: parse_optional_card_with_type::<f64>(h, "BP_4_2")?,
-            bp_0_3: parse_optional_card_with_type::<f64>(h, "BP_0_3")?,
-            bp_1_3: parse_optional_card_with_type::<f64>(h, "BP_1_3")?,
-            bp_2_3: parse_optional_card_with_type::<f64>(h, "BP_2_3")?,
-            bp_3_3: parse_optional_card_with_type::<f64>(h, "BP_3_3")?,
-            bp_0_4: parse_optional_card_with_type::<f64>(h, "BP_0_4")?,
-            bp_1_4: parse_optional_card_with_type::<f64>(h, "BP_1_4")?,
-            bp_2_4: parse_optional_card_with_type::<f64>(h, "BP_2_4")?,
-            bp_0_5: parse_optional_card_with_type::<f64>(h, "BP_0_5")?,
-            bp_1_5: parse_optional_card_with_type::<f64>(h, "BP_1_5")?,
-            bp_0_6: parse_optional_card_with_type::<f64>(h, "BP_0_6")?,
-        };
-
+        let params = WCSParams::deserialize(h.into_deserializer())?;
         WCS::new(&params).map_err(|e| e.into())
     }
 }


### PR DESCRIPTION
Inspired by similar integration in [rust-fitsio](https://github.com/simonrw/rust-fitsio), I've implemented Serde integration for FITS headers and individual values.

This allows to parse arbitrary types instead of doing manual casts everywhere, as well as declaratively describe complex structures. For most notable demo, see the amount of removed code in `wcs.rs` - `WCSParams` already derives `Deserialize`, so now that we implement `Deserializer`, it's pretty trivial to connect the two.

For custom field extractions, I've also wrapped `HashMap<String, Value>` into a new `ValueMap` type which encapsulates `IndexMap<String, Value>` (to get consistent iteration order, something that didn't work correctly before) as well as all the previously existing helper methods that don't need the whole `Header`.