### PR TITLE
Fix-select-fields-order

### DIFF
--- a/src/hdu/data/bintable/data.rs
+++ b/src/hdu/data/bintable/data.rs
@@ -265,6 +265,8 @@ impl<R> TableData<R> {
             }
         ).collect();
 
+        self.cols_idx.sort_unstable();
+
         // We must go to the first column at this point
         self.seek_to_first_col = true;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,9 +361,11 @@ mod tests {
                     .get_data(&hdu)
                     .table_data()
                     .select_fields(&[
-                        ColumnId::Name("mag"),
+                        // Note: fields are intentionally selected out of order
+                        // to test that we don't rely on the order of fields.
                         ColumnId::Name("phot_bp_mean_mag"),
                         ColumnId::Name("phot_rp_mean_mag"),
+                        ColumnId::Name("mag"),
                     ])
                     .collect();
 


### PR DESCRIPTION
Fixes #31 by sorting the selected columns so that they're in the expected seekable order.