### PR TITLE
Correctly print slice returned by get_naxis

### DIFF
--- a/crates/cli/src/struct.rs
+++ b/crates/cli/src/struct.rs
@@ -85,7 +85,7 @@ where
 
 fn print_img_header(img: &Image) {
     println!(
-        " * HEAD naxis: {}; bitpix : {:?}; dimensions: {}.",
+        " * HEAD naxis: {:?}; bitpix : {:?}; dimensions: {}.",
         img.get_naxis(),
         img.get_bitpix(),
         img.get_naxis()


### PR DESCRIPTION
`get_naxis()` returns a slice which doesn't derive Debug.